### PR TITLE
feat: [RTR-227] admin code 인증 적용 기능 및 즉시 승인/거절/조회용 API 구현

### DIFF
--- a/src/main/java/retrivr/retrivrspring/application/service/admin/auth/AdminCodeVerificationService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/admin/auth/AdminCodeVerificationService.java
@@ -85,4 +85,27 @@ public class AdminCodeVerificationService {
     // 토큰 논리적 삭제
     token.markUsed(now);
   }
+
+  public void validateAdminCodeVerificationToken(Organization organization, AdminCodeVerificationPurpose purpose, String rawToken) {
+    LocalDateTime now = LocalDateTime.now();
+
+    AdminCodeVerificationToken token = adminCodeVerificationTokenRepository.findByOrganizationAndPurpose(
+            organization, purpose)
+        .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_ADMIN_CODE_VERIFICATION_TOKEN));
+
+    // 토큰 값의 일치 여부 검증
+    if (!passwordEncoder.matches(rawToken, token.getTokenHash())) {
+      throw new ApplicationException(ErrorCode.ADMIN_CODE_VERIFICATION_TOKEN_MISMATCH);
+    }
+
+    // 토큰 만료 여부 검증
+    if (token.isExpired(now)) {
+      throw new ApplicationException(ErrorCode.EXPIRED_ADMIN_CODE_VERIFICATION_TOKEN);
+    }
+
+    // 토큰 사용 여부 검증
+    if (token.isUsed()) {
+      throw new ApplicationException(ErrorCode.ALREADY_USED_ADMIN_CODE_VERIFICATION_TOKEN);
+    }
+  }
 }

--- a/src/main/java/retrivr/retrivrspring/application/service/admin/item/AdminItemService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/admin/item/AdminItemService.java
@@ -6,6 +6,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import retrivr.retrivrspring.application.port.id.PublicIdGenerator;
+import retrivr.retrivrspring.application.service.admin.auth.AdminCodeVerificationService;
 import retrivr.retrivrspring.application.vo.DefaultNormalizedCursorPageSearchSize;
 import retrivr.retrivrspring.application.service.admin.item.support.AdminItemUnitChangeClassifier;
 import retrivr.retrivrspring.application.service.admin.item.support.AdminItemUnitChangeClassifier.AdminItemUnitChangeSet;
@@ -15,6 +16,7 @@ import retrivr.retrivrspring.domain.entity.item.ItemUnit;
 import retrivr.retrivrspring.domain.entity.item.enumerate.ItemManagementType;
 import retrivr.retrivrspring.domain.entity.item.enumerate.ItemUnitStatus;
 import retrivr.retrivrspring.domain.entity.organization.Organization;
+import retrivr.retrivrspring.domain.entity.organization.enumerate.AdminCodeVerificationPurpose;
 import retrivr.retrivrspring.domain.repository.item.ItemBorrowerFieldRepository;
 import retrivr.retrivrspring.domain.repository.item.ItemRepository;
 import retrivr.retrivrspring.domain.repository.item.ItemUnitRepository;
@@ -47,6 +49,7 @@ public class AdminItemService {
     private final ItemUnitRepository itemUnitRepository;
     private final AdminItemUnitChangeClassifier adminItemUnitChangeClassifier;
     private final PublicIdGenerator publicIdGenerator;
+    private final AdminCodeVerificationService adminCodeVerificationService;
 
     private static final int MAX_PUBLIC_ID_RETRY = 5;
 
@@ -95,6 +98,12 @@ public class AdminItemService {
     @Transactional
     public AdminItemUpdateResponse updateItem(Long organizationId, Long itemId,
                                               AdminItemUpdateRequest request) {
+        Organization organization = organizationRepository.findById(organizationId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_ORGANIZATION));
+        
+        // 관리자 코드 인증 토큰 검증
+        adminCodeVerificationService.validateAndConsumeAdminCodeVerificationToken(
+            organization, AdminCodeVerificationPurpose.ITEM_UPDATE, request.adminCodeVerificationToken());
 
         Item item = itemRepository.findFetchItemBorrowerFieldsByIdAndOrganization_Id(itemId,
                         organizationId)

--- a/src/main/java/retrivr/retrivrspring/application/service/admin/profile/AdminProfileService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/admin/profile/AdminProfileService.java
@@ -10,9 +10,11 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import retrivr.retrivrspring.application.port.image.ImageStoragePort;
 import retrivr.retrivrspring.application.port.image.PresignedUploadUrl;
 import retrivr.retrivrspring.application.port.image.ProfileImageKeyGeneratorPort;
+import retrivr.retrivrspring.application.service.admin.auth.AdminCodeVerificationService;
 import retrivr.retrivrspring.domain.entity.organization.AdminAuthCodeHash;
 import retrivr.retrivrspring.domain.entity.organization.Organization;
 import retrivr.retrivrspring.domain.entity.organization.PasswordHash;
+import retrivr.retrivrspring.domain.entity.organization.enumerate.AdminCodeVerificationPurpose;
 import retrivr.retrivrspring.domain.repository.organization.OrganizationRepository;
 import retrivr.retrivrspring.global.error.ApplicationException;
 import retrivr.retrivrspring.global.error.ErrorCode;
@@ -35,6 +37,7 @@ public class AdminProfileService {
     private final PasswordEncoder passwordEncoder;
     private final ProfileImageKeyGeneratorPort profileImageKeyGeneratorPort;
     private final ImageStoragePort imageStoragePort;
+    private final AdminCodeVerificationService adminCodeVerificationService;
 
     @Transactional(readOnly = true)
     public AdminProfileResponse getProfile(Long organizationId) {
@@ -52,6 +55,10 @@ public class AdminProfileService {
     public AdminProfileResponse updateProfile(Long organizationId, AdminProfileUpdateRequest request) {
         Organization organization = organizationRepository.findById(organizationId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_ORGANIZATION));
+
+        // 관리자 코드 인증 토큰 검증
+        adminCodeVerificationService.validateAndConsumeAdminCodeVerificationToken(
+            organization, AdminCodeVerificationPurpose.ORGANIZATION_UPDATE, request.adminCodeVerificationToken());
 
         String normalizedEmail = request.newEmail().trim().toLowerCase(Locale.ROOT);
         String organizationName = request.newOrganizationName().trim();

--- a/src/main/java/retrivr/retrivrspring/application/service/admin/rental/AdminRequestedRentalService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/admin/rental/AdminRequestedRentalService.java
@@ -59,13 +59,13 @@ public class AdminRequestedRentalService {
 
   @Transactional
   public AdminRentalDecisionResponse approveRentalRequest(Long rentalId,
-      AdminRentalApproveRequest request, Long mockOrganizationId) {
+      AdminRentalApproveRequest request, Long loginOrganizationId) {
     // 1. 요청된 Rental 조회
     Rental rental = rentalRepository.findFetchRentalItemAndOrganizationByIdWithLock(rentalId)
         .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_RENTAL));
 
     // 2. 로그인한 Organization 조회
-    Organization organizationToApprove = organizationRepository.findById(mockOrganizationId)
+    Organization organizationToApprove = organizationRepository.findById(loginOrganizationId)
         .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_ORGANIZATION));
 
     // 3. Rental 을 소유한 Organization 인지 검증

--- a/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
@@ -8,10 +8,15 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import retrivr.retrivrspring.application.event.RentalApprovedEvent;
+import retrivr.retrivrspring.application.event.RentalRejectedEvent;
 import retrivr.retrivrspring.application.event.RentalRequestedEvent;
 import retrivr.retrivrspring.application.port.id.PublicIdGenerator;
+import retrivr.retrivrspring.application.service.admin.auth.AdminCodeVerificationService;
 import retrivr.retrivrspring.domain.entity.item.Item;
 import retrivr.retrivrspring.domain.entity.item.ItemUnit;
+import retrivr.retrivrspring.domain.entity.organization.Organization;
+import retrivr.retrivrspring.domain.entity.organization.enumerate.AdminCodeVerificationPurpose;
 import retrivr.retrivrspring.domain.entity.rental.Borrower;
 import retrivr.retrivrspring.domain.entity.rental.PhoneNumber;
 import retrivr.retrivrspring.domain.entity.rental.Rental;
@@ -20,12 +25,17 @@ import retrivr.retrivrspring.domain.repository.item.ItemUnitRepository;
 import retrivr.retrivrspring.domain.repository.rental.RentalRepository;
 import retrivr.retrivrspring.global.error.ApplicationException;
 import retrivr.retrivrspring.global.error.ErrorCode;
+import retrivr.retrivrspring.presentation.admin.rental.res.AdminRentalDecisionResponse;
 import retrivr.retrivrspring.presentation.open.rental.req.PublicRentalCreateRequest;
+import retrivr.retrivrspring.presentation.open.rental.req.PublicRentalImmediateApproveRequest;
+import retrivr.retrivrspring.presentation.open.rental.req.PublicRentalImmediateRejectRequest;
 import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalCreateResponse;
 import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalDetailResponse;
 
 import java.util.HashMap;
 import java.util.Map;
+import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalImmediateApproveResponse;
+import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalImmediateRejectResponse;
 
 @Slf4j
 @Service
@@ -39,6 +49,7 @@ public class PublicRentalService {
   private final ItemUnitRepository itemUnitRepository;
   private final ApplicationEventPublisher applicationEventPublisher;
   private final PublicIdGenerator publicIdGenerator;
+  private final AdminCodeVerificationService adminCodeVerificationService;
 
   private static final int MAX_PUBLIC_ID_RETRY = 5;
 
@@ -77,15 +88,18 @@ public class PublicRentalService {
         request.itemUnitId(), requestedRental.getRequestedAt());
   }
 
-  public PublicRentalDetailResponse checkRentalStatusAndDetail(Long rentalId) {
+  public PublicRentalDetailResponse checkRentalStatusAndDetail(Long rentalId, String token) {
     Rental rental = rentalRepository.findById(rentalId)
         .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_RENTAL));
 
+    adminCodeVerificationService.validateAdminCodeVerificationToken(
+        rental.getOrganization(), AdminCodeVerificationPurpose.IMMEDIATE_APPROVAL, token);
+
     //todo: 장바구니? 기능 이후 name List 를 넘기도록 수정
-    String itemName = rental.getRentalItems().getFirst().getItem().getName();
+    String itemName = rental.getItem().getName();
     String itemUnitLabel = null;
-    if (!rental.getRentalItemUnits().isEmpty()) {
-      itemUnitLabel = rental.getRentalItemUnits().getFirst().getItemUnit().getLabel();
+    if (rental.hasItemUnit()) {
+      itemUnitLabel = rental.getItemUnit().getLabel();
     }
 
     Map<String, String> borrowerField = new HashMap<>();
@@ -117,5 +131,46 @@ public class PublicRentalService {
     }
 
     throw new ApplicationException(ErrorCode.RENTAL_PUBLIC_ID_GENERATE_FAILED);
+  }
+
+  @Transactional
+  public PublicRentalImmediateApproveResponse approveRentalRequest(Long rentalId, PublicRentalImmediateApproveRequest request) {
+    // 요청된 Rental 조회
+    Rental rental = rentalRepository.findFetchRentalItemAndOrganizationByIdWithLock(rentalId)
+        .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_RENTAL));
+
+    Organization organization = rental.getOrganization();
+
+    // 관리자 코드 인증 토큰 검증
+    adminCodeVerificationService.validateAndConsumeAdminCodeVerificationToken(
+        organization, AdminCodeVerificationPurpose.IMMEDIATE_APPROVAL, request.adminCodeVerificationToken());
+
+    // 대여 요청 승인
+    rental.approve(request.adminNameToApprove(), organization);
+    applicationEventPublisher.publishEvent(new RentalApprovedEvent(rental.getId()));
+
+    return new PublicRentalImmediateApproveResponse(organization.getId());
+  }
+
+  @Transactional
+  public PublicRentalImmediateRejectResponse rejectRentalRequest(Long rentalId, PublicRentalImmediateRejectRequest request) {
+
+    // 1. 대여 정보 조회
+    Rental rental = rentalRepository.findFetchRentalItemAndOrganizationByIdWithLock(rentalId)
+        .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_RENTAL));
+
+    // 2. 로그인된 조직 조회
+    Organization organization = rental.getOrganization();
+
+    // 관리자 코드 인증 토큰 검증
+    adminCodeVerificationService.validateAndConsumeAdminCodeVerificationToken(
+        organization, AdminCodeVerificationPurpose.IMMEDIATE_APPROVAL, request.adminCodeVerificationToken());
+
+
+    // 3. 대여 거부
+    rental.reject(request.adminNameToReject(), organization);
+    applicationEventPublisher.publishEvent(new RentalRejectedEvent(rental.getId()));
+
+    return new PublicRentalImmediateRejectResponse(organization.getId());
   }
 }

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/item/req/AdminItemUpdateRequest.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/item/req/AdminItemUpdateRequest.java
@@ -52,6 +52,10 @@ public record AdminItemUpdateRequest(
 
     @Schema(description = "활성 여부", example = "true")
     @NotNull
-    Boolean isActive
+    Boolean isActive,
+
+    @Schema(description = "관리자 코드 인증 토큰", example = "cvt_token")
+    @NotNull
+    String adminCodeVerificationToken
 ) {
 }

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/item/req/AdminItemUpdateRequest.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/item/req/AdminItemUpdateRequest.java
@@ -55,7 +55,7 @@ public record AdminItemUpdateRequest(
     Boolean isActive,
 
     @Schema(description = "관리자 코드 인증 토큰", example = "cvt_token")
-    @NotNull
+    @NotBlank
     String adminCodeVerificationToken
 ) {
 }

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/profile/AdminProfileController.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/profile/AdminProfileController.java
@@ -94,7 +94,7 @@ public class AdminProfileController {
 
     @PutMapping("/images")
     @Operation(
-        summary = "관리자 프로필 수정 확정",
+        summary = "관리자 프로필 이미지 수정 확정",
         description = "관리자 프로필을 입력된 ObjectKey 로 대체합니다."
     )
     @ApiResponse(

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/profile/req/AdminProfileUpdateRequest.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/profile/req/AdminProfileUpdateRequest.java
@@ -1,7 +1,9 @@
 package retrivr.retrivrspring.presentation.admin.profile.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record AdminProfileUpdateRequest(
         @Email
@@ -18,6 +20,10 @@ public record AdminProfileUpdateRequest(
         String newOrganizationName,
 
         @NotBlank
-        String newAdminCode
+        String newAdminCode,
+
+        @NotBlank
+        @Schema(description = "관리자 인증 번호 검증 후 받은 토큰", example = "cvt_token")
+        String adminCodeVerificationToken
 ) {
 }

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/PublicRentalController.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/PublicRentalController.java
@@ -55,7 +55,7 @@ public class PublicRentalController {
       description = "대여 정보 조회 성공",
       content = @Content(schema = @Schema(implementation = PublicRentalDetailResponse.class))
   )
-  @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_RENTAL})
+  @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_RENTAL, ErrorCode.NOT_FOUND_ADMIN_CODE_VERIFICATION_TOKEN, ErrorCode.ADMIN_CODE_VERIFICATION_TOKEN_MISMATCH, ErrorCode.EXPIRED_ADMIN_CODE_VERIFICATION_TOKEN, ErrorCode.ALREADY_USED_ADMIN_CODE_VERIFICATION_TOKEN})
   public PublicRentalDetailResponse getRentalInfo(
       @PathVariable("rentalId") Long rentalId,
       @RequestParam(name = "token") String token
@@ -78,7 +78,7 @@ public class PublicRentalController {
     return publicRentalService.approveRentalRequest(rentalId, request);
   }
 
-  @PostMapping("rentals/{rentalId}/reject")
+  @PostMapping("/rentals/{rentalId}/reject")
   @Operation(summary = "대여 요청 현장 즉시 거부")
   @ApiResponse(
       responseCode = "200",

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/PublicRentalController.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/PublicRentalController.java
@@ -12,13 +12,18 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import retrivr.retrivrspring.application.service.open.PublicRentalService;
 import retrivr.retrivrspring.global.error.ErrorCode;
 import retrivr.retrivrspring.global.swagger.annotation.ApiErrorCodeExamples;
 import retrivr.retrivrspring.presentation.open.rental.req.PublicRentalCreateRequest;
+import retrivr.retrivrspring.presentation.open.rental.req.PublicRentalImmediateApproveRequest;
+import retrivr.retrivrspring.presentation.open.rental.req.PublicRentalImmediateRejectRequest;
 import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalCreateResponse;
 import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalDetailResponse;
+import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalImmediateApproveResponse;
+import retrivr.retrivrspring.presentation.open.rental.res.PublicRentalImmediateRejectResponse;
 
 @RequiredArgsConstructor
 @RestController
@@ -44,7 +49,7 @@ public class PublicRentalController {
   }
 
   @GetMapping("/rentals/{rentalId}")
-  @Operation(summary = "대여 상태/대여 정보 조회(확인 완료 확인용)")
+  @Operation(summary = "대여 상태/대여 정보 조회(현장 즉시 완료용)")
   @ApiResponse(
       responseCode = "200",
       description = "대여 정보 조회 성공",
@@ -52,9 +57,39 @@ public class PublicRentalController {
   )
   @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_RENTAL})
   public PublicRentalDetailResponse getRentalInfo(
-      @PathVariable("rentalId") Long rentalId
+      @PathVariable("rentalId") Long rentalId,
+      @RequestParam(name = "token") String token
   ) {
-    return publicRentalService.checkRentalStatusAndDetail(rentalId);
+    return publicRentalService.checkRentalStatusAndDetail(rentalId, token);
   }
 
+  @PostMapping("/rentals/{rentalId}/approve")
+  @Operation(summary = "대여 요청 현장 즉시 승인")
+  @ApiResponse(
+      responseCode = "200",
+      description = "승인 처리 성공",
+      content = @Content(schema = @Schema(implementation = PublicRentalImmediateApproveResponse.class))
+  )
+  @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_RENTAL, ErrorCode.RENTAL_STATUS_TRANSITION_EXCEPTION, ErrorCode.AVAILABLE_QUANTITY_UNDERFLOW_EXCEPTION, ErrorCode.ITEM_STATUS_TRANSITION_EXCEPTION})
+  public PublicRentalImmediateApproveResponse approve(
+      @PathVariable Long rentalId,
+      @Valid @RequestBody PublicRentalImmediateApproveRequest request
+  ) {
+    return publicRentalService.approveRentalRequest(rentalId, request);
+  }
+
+  @PostMapping("rentals/{rentalId}/reject")
+  @Operation(summary = "대여 요청 현장 즉시 거부")
+  @ApiResponse(
+      responseCode = "200",
+      description = "거부 처리 성공",
+      content = @Content(schema = @Schema(implementation = PublicRentalImmediateRejectResponse.class))
+  )
+  @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_RENTAL, ErrorCode.NOT_FOUND_ORGANIZATION, ErrorCode.RENTAL_STATUS_TRANSITION_EXCEPTION, ErrorCode.ORGANIZATION_MISMATCH_EXCEPTION, ErrorCode.AVAILABLE_QUANTITY_OVERFLOW_EXCEPTION, ErrorCode.ITEM_STATUS_TRANSITION_EXCEPTION})
+  public PublicRentalImmediateRejectResponse reject(
+      @PathVariable Long rentalId,
+      @Valid @RequestBody PublicRentalImmediateRejectRequest request
+  ) {
+    return publicRentalService.rejectRentalRequest(rentalId, request);
+  }
 }

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/req/PublicRentalImmediateApproveRequest.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/req/PublicRentalImmediateApproveRequest.java
@@ -1,0 +1,26 @@
+package retrivr.retrivrspring.presentation.open.rental.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PublicRentalImmediateApproveRequest(
+    @Schema(
+        description = "대여 승인을 처리한 관리자 이름",
+        example = "김관리",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "관리자 이름은 필수입니다.")
+    @Size(max = 100, message = "관리자 이름은 100자 이하로 입력해주세요.")
+    String adminNameToApprove,
+
+    @Schema(
+        description = "관리자 코드 인증 토큰",
+        example = "cvt_token",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank
+    String adminCodeVerificationToken
+) {
+
+}

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/req/PublicRentalImmediateRejectRequest.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/req/PublicRentalImmediateRejectRequest.java
@@ -1,0 +1,26 @@
+package retrivr.retrivrspring.presentation.open.rental.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PublicRentalImmediateRejectRequest(
+    @Schema(
+        description = "대여 거절을 처리한 관리자 이름",
+        example = "김관리",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "관리자 이름은 필수입니다.")
+    @Size(max = 100, message = "관리자 이름은 100자 이하로 입력해주세요.")
+    String adminNameToReject,
+
+    @Schema(
+        description = "관리자 코드 인증 토큰",
+        example = "cvt_token",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank
+    String adminCodeVerificationToken
+) {
+
+}

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalDetailResponse.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalDetailResponse.java
@@ -1,19 +1,15 @@
 package retrivr.retrivrspring.presentation.open.rental.res;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 import retrivr.retrivrspring.domain.entity.rental.Rental;
-import retrivr.retrivrspring.domain.entity.rental.enumerate.RentalStatus;
 
 public record PublicRentalDetailResponse(
     Long rentalId,
-    RentalStatus rentalStatus,
     String itemName,
     String itemUnitLabel,
     Map<String, String> borrowerField,
-    LocalDateTime decidedAt,
-    LocalDate dueDate
+    LocalDateTime requestedAt
 ) {
 
   public static PublicRentalDetailResponse from(
@@ -24,12 +20,10 @@ public record PublicRentalDetailResponse(
   ) {
     return new PublicRentalDetailResponse(
         rental.getId(),
-        rental.getStatus(),
         itemName,
         itemUnitLabel,
         borrowerField,
-        rental.getDecidedAt(),
-        rental.getDueDate()
+        rental.getRequestedAt()
     );
   }
 

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalImmediateApproveResponse.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalImmediateApproveResponse.java
@@ -1,0 +1,7 @@
+package retrivr.retrivrspring.presentation.open.rental.res;
+
+public record PublicRentalImmediateApproveResponse(
+    Long organizationId
+) {
+
+}

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalImmediateRejectResponse.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalImmediateRejectResponse.java
@@ -1,0 +1,7 @@
+package retrivr.retrivrspring.presentation.open.rental.res;
+
+public record PublicRentalImmediateRejectResponse(
+    Long organizationId
+) {
+
+}

--- a/src/test/java/retrivr/retrivrspring/application/service/AdminProfileServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/AdminProfileServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import retrivr.retrivrspring.application.service.admin.auth.AdminCodeVerificationService;
 import retrivr.retrivrspring.application.service.admin.profile.AdminProfileService;
 import retrivr.retrivrspring.domain.entity.organization.Organization;
 import retrivr.retrivrspring.domain.entity.organization.enumerate.OrganizationStatus;
@@ -31,6 +32,9 @@ class AdminProfileServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AdminCodeVerificationService adminCodeVerificationService;
 
     @InjectMocks
     private AdminProfileService adminProfileService;
@@ -59,7 +63,8 @@ class AdminProfileServiceTest {
                         "NewPassword123!",
                         "NewPassword123!",
                         "New Org",
-                        "new-admin-code"
+                        "new-admin-code",
+                    "token"
                 )
         );
 
@@ -102,7 +107,8 @@ class AdminProfileServiceTest {
                                 "NewPassword123!",
                                 "NewPassword123!",
                                 "New Org",
-                                "new-admin-code"
+                                "new-admin-code",
+                            "token"
                         )
                 )
         );
@@ -135,7 +141,8 @@ class AdminProfileServiceTest {
                                 "NewPassword123!",
                                 "DifferentPassword123!",
                                 "New Org",
-                                "new-admin-code"
+                                "new-admin-code",
+                            "token"
                         )
                 )
         );

--- a/src/test/java/retrivr/retrivrspring/application/service/item/AdminItemServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/item/AdminItemServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import retrivr.retrivrspring.application.port.id.PublicIdGenerator;
+import retrivr.retrivrspring.application.service.admin.auth.AdminCodeVerificationService;
 import retrivr.retrivrspring.application.service.admin.item.AdminItemService;
 import retrivr.retrivrspring.application.service.admin.item.support.AdminItemUnitChangeClassifier;
 import retrivr.retrivrspring.domain.entity.item.Item;
@@ -50,6 +51,7 @@ class AdminItemServiceTest {
   @Mock private ItemUnitRepository itemUnitRepository;
   @Mock private AdminItemUnitChangeClassifier adminItemUnitChangeClassifier;
   @Mock private PublicIdGenerator publicIdGenerator;
+  @Mock private AdminCodeVerificationService adminCodeVerificationService;
 
   @InjectMocks
   private AdminItemService adminItemService;
@@ -144,6 +146,7 @@ class AdminItemServiceTest {
     setQuantities(item, 1, 1);
     ItemUnit existingUnit = createItemUnit(201L, item, "unit-a", ItemUnitStatus.AVAILABLE);
 
+    when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
     when(itemRepository.findFetchItemBorrowerFieldsByIdAndOrganization_Id(itemId, organizationId))
         .thenReturn(Optional.of(item));
     when(itemBorrowerFieldRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -170,6 +173,7 @@ class AdminItemServiceTest {
     ItemUnit firstUnit = createItemUnit(201L, item, "unit-a", ItemUnitStatus.AVAILABLE);
     ItemUnit lastUnit = createItemUnit(202L, item, "unit-b", ItemUnitStatus.AVAILABLE);
 
+    when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
     when(itemRepository.findFetchItemBorrowerFieldsByIdAndOrganization_Id(itemId, organizationId))
         .thenReturn(Optional.of(item));
     when(itemUnitRepository.findAllByItemId(itemId)).thenReturn(List.of(firstUnit, lastUnit));
@@ -197,6 +201,7 @@ class AdminItemServiceTest {
     setQuantities(item, 2, 2);
     List<ItemUnit> savedUnits = new ArrayList<>();
 
+    when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
     when(itemRepository.findFetchItemBorrowerFieldsByIdAndOrganization_Id(itemId, organizationId))
         .thenReturn(Optional.of(item));
     when(itemUnitRepository.findAllByItemId(itemId)).thenReturn(List.of()).thenAnswer(invocation -> new ArrayList<>(savedUnits));
@@ -236,6 +241,7 @@ class AdminItemServiceTest {
     ItemUnit firstUnit = createItemUnit(201L, item, "unit-a", ItemUnitStatus.AVAILABLE);
     ItemUnit secondUnit = createItemUnit(202L, item, "unit-b", ItemUnitStatus.AVAILABLE);
 
+    when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
     when(itemRepository.findFetchItemBorrowerFieldsByIdAndOrganization_Id(itemId, organizationId))
         .thenReturn(Optional.of(item));
     when(itemUnitRepository.findAllByItemId(itemId))
@@ -264,6 +270,7 @@ class AdminItemServiceTest {
     setQuantities(item, 1, 1);
     ItemUnit existingUnit = createItemUnit(201L, item, "unit-a", ItemUnitStatus.AVAILABLE);
 
+    when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
     when(itemRepository.findFetchItemBorrowerFieldsByIdAndOrganization_Id(itemId, organizationId))
         .thenReturn(Optional.of(item));
     when(itemUnitRepository.findAllByItemId(itemId)).thenReturn(List.of(existingUnit));
@@ -319,7 +326,8 @@ class AdminItemServiceTest {
         "student id",
         unitChanges,
         List.of(new BorrowerRequirementRequest("name", true)),
-        true
+        true,
+        "token"
     );
   }
 

--- a/src/test/java/retrivr/retrivrspring/application/service/rental/PublicRentalServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/rental/PublicRentalServiceTest.java
@@ -31,6 +31,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationEventPublisher;
 import retrivr.retrivrspring.application.event.RentalRequestedEvent;
 import retrivr.retrivrspring.application.port.id.PublicIdGenerator;
+import retrivr.retrivrspring.application.service.admin.auth.AdminCodeVerificationService;
 import retrivr.retrivrspring.application.service.open.PublicRentalService;
 import retrivr.retrivrspring.domain.entity.item.Item;
 import retrivr.retrivrspring.domain.entity.item.ItemUnit;
@@ -59,6 +60,7 @@ class PublicRentalServiceTest {
   @Mock private ItemUnitRepository itemUnitRepository;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
   @Mock private PublicIdGenerator publicIdGenerator;
+  @Mock private AdminCodeVerificationService adminCodeVerificationService;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -69,7 +71,8 @@ class PublicRentalServiceTest {
         itemRepository,
         itemUnitRepository,
         applicationEventPublisher,
-        publicIdGenerator
+        publicIdGenerator,
+        adminCodeVerificationService
     );
   }
 
@@ -198,7 +201,7 @@ class PublicRentalServiceTest {
   void checkRental_notFound() {
     when(rentalRepository.findById(777L)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service().checkRentalStatusAndDetail(777L))
+    assertThatThrownBy(() -> service().checkRentalStatusAndDetail(777L, "token"))
         .isInstanceOf(ApplicationException.class);
   }
 
@@ -206,7 +209,9 @@ class PublicRentalServiceTest {
   @DisplayName("PR-09: detail without unit")
   void checkRental_detail_withoutUnit() {
     Rental rental = mock(Rental.class);
+    Organization org = mockOrg(1L);
     when(rental.getId()).thenReturn(1L);
+    when(rental.getOrganization()).thenReturn(org);
     when(rental.getStatus()).thenReturn(RentalStatus.REQUESTED);
     when(rental.getDecidedAt()).thenReturn((LocalDateTime) null);
     when(rental.getDueDate()).thenReturn((LocalDate) null);
@@ -217,6 +222,9 @@ class PublicRentalServiceTest {
     when(rentalItem.getItem()).thenReturn(item);
     when(rental.getRentalItems()).thenReturn(List.of(rentalItem));
     when(rental.getRentalItemUnits()).thenReturn(List.of());
+    when(rental.getItem()).thenReturn(item);
+    when(rental.hasItemUnit()).thenReturn(false);
+
 
     Borrower borrower = mock(Borrower.class);
     JsonNode info = objectMapper.valueToTree(Map.of("학과", "컴공"));
@@ -226,7 +234,7 @@ class PublicRentalServiceTest {
 
     when(rentalRepository.findById(1L)).thenReturn(Optional.of(rental));
 
-    PublicRentalDetailResponse res = service().checkRentalStatusAndDetail(1L);
+    PublicRentalDetailResponse res = service().checkRentalStatusAndDetail(1L, "token");
 
     assertThat(res.itemName()).isEqualTo("카메라");
     assertThat(res.itemUnitLabel()).isNull();
@@ -247,12 +255,17 @@ class PublicRentalServiceTest {
     RentalItem rentalItem = mock(RentalItem.class);
     when(rentalItem.getItem()).thenReturn(item);
     when(rental.getRentalItems()).thenReturn(List.of(rentalItem));
+    when(rental.getItem()).thenReturn(item);
+
 
     ItemUnit unit = mock(ItemUnit.class);
     when(unit.getLabel()).thenReturn("unit-001");
     RentalItemUnit riu = mock(RentalItemUnit.class);
     when(riu.getItemUnit()).thenReturn(unit);
     when(rental.getRentalItemUnits()).thenReturn(List.of(riu));
+    when(rental.getItemUnit()).thenReturn(unit);
+    when(rental.hasItemUnit()).thenReturn(true);
+
 
     Borrower borrower = mock(Borrower.class);
     JsonNode info = objectMapper.valueToTree(Map.of("학번", "20251234"));
@@ -262,7 +275,7 @@ class PublicRentalServiceTest {
 
     when(rentalRepository.findById(2L)).thenReturn(Optional.of(rental));
 
-    PublicRentalDetailResponse res = service().checkRentalStatusAndDetail(2L);
+    PublicRentalDetailResponse res = service().checkRentalStatusAndDetail(2L, "token");
 
     assertThat(res.itemName()).isEqualTo("노트북");
     assertThat(res.itemUnitLabel()).isEqualTo("unit-001");


### PR DESCRIPTION
## 🎟️ Notion Ticket
- [RTR-227] https://www.notion.so/Retrivr-2fca5695293781aeaf76e991b4b74abf?p=34fa5695293780babd97e91e42a473fb&pm=s

## 🔎 작업 내용
- Public 대여 플로우에 현장 즉시 승인 / 거절 / 상세 조회 API 추가
  - GET /open/v1/rentals/{rentalId}?token=...
  - POST /open/v1/rentals/{rentalId}/approve
  - POST /open/v1/rentals/{rentalId}/reject
- AdminCodeVerificationService에 검증 전용(validate only) 메소드 추가
- Item 수정 시 관리자 코드 인증 토큰 검증 적용
- Organization(프로필) 수정 시 관리자 코드 인증 토큰 검증 적용

## ✅ To Reviewer
- 

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료

## 📸 스크린샷/영상 (선택)
- 

## ⚠️ 영향도/주의사항 (선택)
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 항목 업데이트 및 프로필 수정 시 인증 토큰 검증 추가
  * 렌탈 승인/거절을 위한 새로운 엔드포인트 추가
  * 렌탈 상태 조회 시 토큰 기반 접근 제어 구현
  * 렌탈 상세 정보 응답 구조 개선 (요청 일시 필드 추가)

* **Tests**
  * 신규 인증 기능에 맞춰 테스트 케이스 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->