### PR TITLE
feat: [RTR-232] 대여 즉시 승인용 관리자 인증 코드 검증 API 구현

### DIFF
--- a/src/main/java/retrivr/retrivrspring/application/service/admin/auth/AdminCodeVerificationService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/admin/auth/AdminCodeVerificationService.java
@@ -9,12 +9,16 @@ import org.springframework.transaction.annotation.Transactional;
 import retrivr.retrivrspring.domain.entity.organization.AdminCodeVerificationToken;
 import retrivr.retrivrspring.domain.entity.organization.Organization;
 import retrivr.retrivrspring.domain.entity.organization.enumerate.AdminCodeVerificationPurpose;
+import retrivr.retrivrspring.domain.entity.rental.Rental;
 import retrivr.retrivrspring.domain.repository.auth.AdminCodeVerificationTokenRepository;
 import retrivr.retrivrspring.domain.repository.organization.OrganizationRepository;
+import retrivr.retrivrspring.domain.repository.rental.RentalRepository;
 import retrivr.retrivrspring.global.error.ApplicationException;
 import retrivr.retrivrspring.global.error.ErrorCode;
 import retrivr.retrivrspring.presentation.admin.auth.req.AdminCodeVerificationRequest;
+import retrivr.retrivrspring.presentation.admin.auth.req.AdminCodeVerificationRequestForPublic;
 import retrivr.retrivrspring.presentation.admin.auth.res.AdminCodeVerificationResponse;
+import retrivr.retrivrspring.presentation.admin.auth.res.AdminCodeVerificationResponseForPublic;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ import retrivr.retrivrspring.presentation.admin.auth.res.AdminCodeVerificationRe
 public class AdminCodeVerificationService {
 
   private final OrganizationRepository organizationRepository;
+  private final RentalRepository rentalRepository;
   private final AdminCodeVerificationTokenRepository adminCodeVerificationTokenRepository;
   private final PasswordEncoder passwordEncoder;
 
@@ -57,6 +62,42 @@ public class AdminCodeVerificationService {
     adminCodeVerificationTokenRepository.save(token);
 
     return new AdminCodeVerificationResponse(rawToken);
+  }
+
+  @Transactional
+  public AdminCodeVerificationResponseForPublic verifyAdminCode(AdminCodeVerificationRequestForPublic request) {
+    Rental rental = rentalRepository.findById(request.rentalId())
+        .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_RENTAL));
+
+    Organization organization = rental.getOrganization();
+
+    // 관리자 코드가 일치하는지 검증
+    if (!passwordEncoder.matches(request.adminCode(), organization.getAdminCodeHash())) {
+      throw new ApplicationException(ErrorCode.ADMIN_CODE_MISMATCH);
+    }
+
+    // 새로운 토큰 값 생성
+    String rawToken = "cvt_" + UUID.randomUUID();
+    String encodedToken = passwordEncoder.encode(rawToken);
+    LocalDateTime now = LocalDateTime.now();
+
+    // 이미 토큰이 존재한다면 변경, 존재하지 않는다면 생성하여 저장
+    AdminCodeVerificationToken token = adminCodeVerificationTokenRepository
+        .findByOrganizationAndPurpose(organization, request.purpose())
+        .map(existing -> {
+          existing.refresh(encodedToken, now);
+          return existing;
+        })
+        .orElseGet(() -> AdminCodeVerificationToken.create(
+            organization,
+            encodedToken,
+            request.purpose(),
+            now
+        ));
+
+    adminCodeVerificationTokenRepository.save(token);
+
+    return new AdminCodeVerificationResponseForPublic(rawToken, request.rentalId());
   }
 
   @Transactional

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/auth/AdminCodeVerificationController.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/auth/AdminCodeVerificationController.java
@@ -18,17 +18,19 @@ import retrivr.retrivrspring.global.auth.AuthUser;
 import retrivr.retrivrspring.global.error.ErrorCode;
 import retrivr.retrivrspring.global.swagger.annotation.ApiErrorCodeExamples;
 import retrivr.retrivrspring.presentation.admin.auth.req.AdminCodeVerificationRequest;
+import retrivr.retrivrspring.presentation.admin.auth.req.AdminCodeVerificationRequestForPublic;
 import retrivr.retrivrspring.presentation.admin.auth.res.AdminCodeVerificationResponse;
+import retrivr.retrivrspring.presentation.admin.auth.res.AdminCodeVerificationResponseForPublic;
 
 @RestController
-@RequestMapping("/api/admin/v1/admin-code/verification")
+@RequestMapping("/api")
 @Tag(name = "Admin API / Admin Code Verification", description = "관리자 코드 인증 관련 API")
 @RequiredArgsConstructor
 public class AdminCodeVerificationController {
 
   private final AdminCodeVerificationService adminCodeVerificationService;
 
-  @PostMapping
+  @PostMapping("/admin/v1/admin-code/verification")
   @Operation(
       summary = "관리자 코드 검증",
       description = "입력한 관리자 코드를 검증하고, 성공하면 관리자 코드 검증 토큰을 발급합니다."
@@ -47,5 +49,25 @@ public class AdminCodeVerificationController {
       @Parameter(hidden = true) @AuthOrg AuthUser loginUser
   ) {
     return adminCodeVerificationService.verifyAdminCode(loginUser.organizationId(), request);
+  }
+
+  @PostMapping("/public/v1/admin-code/verification")
+  @Operation(
+      summary = "관리자 코드 검증",
+      description = "입력한 관리자 코드를 검증하고, 성공하면 관리자 코드 검증 토큰을 발급합니다."
+  )
+  @ApiResponse(
+      responseCode = "200",
+      description = "검증 성공",
+      content = @Content(schema = @Schema(implementation = AdminCodeVerificationResponseForPublic.class))
+  )
+  @ApiErrorCodeExamples({
+      ErrorCode.NOT_FOUND_ORGANIZATION,
+      ErrorCode.ADMIN_CODE_MISMATCH
+  })
+  public AdminCodeVerificationResponseForPublic verifyAdminCodeForPublic(
+      @Valid @RequestBody AdminCodeVerificationRequestForPublic request
+  ) {
+    return adminCodeVerificationService.verifyAdminCode(request);
   }
 }

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/auth/AdminCodeVerificationController.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/auth/AdminCodeVerificationController.java
@@ -63,6 +63,7 @@ public class AdminCodeVerificationController {
   )
   @ApiErrorCodeExamples({
       ErrorCode.NOT_FOUND_ORGANIZATION,
+      ErrorCode.NOT_FOUND_RENTAL,
       ErrorCode.ADMIN_CODE_MISMATCH
   })
   public AdminCodeVerificationResponseForPublic verifyAdminCodeForPublic(

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/auth/req/AdminCodeVerificationRequestForPublic.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/auth/req/AdminCodeVerificationRequestForPublic.java
@@ -1,0 +1,17 @@
+package retrivr.retrivrspring.presentation.admin.auth.req;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import retrivr.retrivrspring.domain.entity.organization.enumerate.AdminCodeVerificationPurpose;
+
+public record AdminCodeVerificationRequestForPublic(
+    @NotNull
+    @Pattern(regexp = "\\d{6}", message = "관리자 코드는 6자리 숫자여야 합니다.")
+    String adminCode,
+    @NotNull
+    AdminCodeVerificationPurpose purpose,
+    @NotNull
+    Long rentalId
+) {
+
+}

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/auth/res/AdminCodeVerificationResponseForPublic.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/auth/res/AdminCodeVerificationResponseForPublic.java
@@ -1,0 +1,8 @@
+package retrivr.retrivrspring.presentation.admin.auth.res;
+
+public record AdminCodeVerificationResponseForPublic(
+    String rawToken,
+    Long rentalId
+) {
+
+}


### PR DESCRIPTION
## 🎟️ Notion Ticket
- [RTR-232] https://www.notion.so/Retrivr-2fca5695293781aeaf76e991b4b74abf?p=350a56952937802db05ffbd1de1aac6e&pm=s

## 🔎 작업 내용
- 로그인 없이 사용 가능한 관리자 인증 코드 검증 API 구현

## ✅ To Reviewer
- 

## 🧪 테스트
- [x] 로컬 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료

## 📸 스크린샷/영상 (선택)
- 

## ⚠️ 영향도/주의사항 (선택)
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 공개 관리자 코드 검증 API 엔드포인트 추가: 사용자는 임차 ID, 관리자 코드, 용도를 제공하여 관리자 코드를 검증하고 토큰을 획득할 수 있습니다. 시스템은 제공된 코드를 조직에 저장된 해시와 검증하고, 유효성 검사 실패 시 오류를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->