### PR TITLE
feat: [RTR-192] 알림톡 구현 및 기본 알림 채널 변경 

### DIFF
--- a/src/main/java/retrivr/retrivrspring/application/event/RentalNotificationEventListener.java
+++ b/src/main/java/retrivr/retrivrspring/application/event/RentalNotificationEventListener.java
@@ -1,15 +1,18 @@
 package retrivr.retrivrspring.application.event;
 
-import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import retrivr.retrivrspring.application.service.message.SendMessageService;
 import retrivr.retrivrspring.domain.entity.rental.Rental;
 import retrivr.retrivrspring.domain.repository.rental.RentalRepository;
+
+import java.util.function.Consumer;
 
 @Component
 @Slf4j
@@ -20,24 +23,28 @@ public class RentalNotificationEventListener {
   private final SendMessageService sendMessageService;
 
   @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleRentalRequested(RentalRequestedEvent event) {
     handleNotification(event.rentalId(), this::sendRequestCompleted, "request completed");
   }
 
   @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleRentalApproved(RentalApprovedEvent event) {
     handleNotification(event.rentalId(), this::sendRentalApproved, "rental approved");
   }
 
   @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleRentalRejected(RentalRejectedEvent event) {
     handleNotification(event.rentalId(), this::sendRentalRejected, "rental rejected");
   }
 
   @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleRentalReturned(RentalReturnedEvent event) {
     handleNotification(event.rentalId(), this::sendReturnConfirmed, "return confirmed");
@@ -47,13 +54,20 @@ public class RentalNotificationEventListener {
     try {
       rentalRepository.findFetchBorrowerRentalItemAndOrganizationById(rentalId)
           .ifPresentOrElse(
-              sender,
+              rental -> sender.accept(loadRentalWithItemUnits(rental)),
               () -> log.warn("Skip {} notification. rentalId={} not found", notificationType, rentalId)
           );
     } catch (Exception e) {
       log.error("{} notification failed. rentalId={}", notificationType, rentalId, e);
     }
   }
+
+  // 이벤트 리스너에서 별도 트랜잭션으로 실행되므로 LAZY 연관 객체 접근 시 예외 방지를 위해 미리 fetch
+  private Rental loadRentalWithItemUnits(Rental rental) {
+    rentalRepository.findFetchRentalItemUnitsByRentalIn(java.util.List.of(rental));
+    return rental;
+  }
+
 
   private void sendRequestCompleted(Rental rental) {
     sendMessageService.sendRequestCompleted(rental);

--- a/src/main/java/retrivr/retrivrspring/application/service/admin/auth/EmailVerificationService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/admin/auth/EmailVerificationService.java
@@ -19,7 +19,6 @@ import retrivr.retrivrspring.global.properties.EmailVerificationProperties;
 import retrivr.retrivrspring.presentation.admin.auth.req.EmailVerificationRequest;
 import retrivr.retrivrspring.presentation.admin.auth.req.EmailVerificationSendRequest;
 import retrivr.retrivrspring.presentation.admin.auth.res.EmailCodeVerifyTokenResponse;
-import retrivr.retrivrspring.presentation.admin.auth.res.EmailVerificationResponse;
 import retrivr.retrivrspring.presentation.admin.auth.res.EmailVerificationSendResponse;
 
 import java.security.SecureRandom;
@@ -88,7 +87,7 @@ public class EmailVerificationService {
     }
 
     @Transactional(noRollbackFor = ApplicationException.class)
-    public Object verify(EmailVerificationRequest request) {
+    public EmailCodeVerifyTokenResponse verify(EmailVerificationRequest request) {
 
         String email = request.email().trim().toLowerCase(Locale.ROOT);
         EmailVerificationPurpose purpose = request.purpose();
@@ -176,12 +175,7 @@ public class EmailVerificationService {
             );
         }
 
-        // 그 외 purpose는 일반 인증 응답
-        return new EmailVerificationResponse(
-                email,
-                true,
-                verification.getVerifiedAt()
-        );
+        throw new ApplicationException(ErrorCode.INVALID_VALUE_EXCEPTION);
     }
 
     private String generateCode() {

--- a/src/main/java/retrivr/retrivrspring/application/service/message/NotificationDispatcher.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/message/NotificationDispatcher.java
@@ -13,12 +13,13 @@ import retrivr.retrivrspring.domain.message.MessageSendStatus;
 import retrivr.retrivrspring.domain.message.MessageType;
 import retrivr.retrivrspring.global.error.ApplicationException;
 import retrivr.retrivrspring.global.error.ErrorCode;
+import retrivr.retrivrspring.global.error.InfraException;
 
 @Component
 @Slf4j
 public class NotificationDispatcher {
 
-  private static final NotificationChannel DEFAULT_CHANNEL = NotificationChannel.EMAIL;
+  private static final NotificationChannel DEFAULT_CHANNEL = NotificationChannel.ALIM_TALK;
 
   private final Map<NotificationChannel, MessageSender> messageSenders;
 
@@ -27,28 +28,36 @@ public class NotificationDispatcher {
   }
 
   public NotificationDispatchResult dispatch(NotificationRequest request, Rental rental) {
-    if (!request.supports(DEFAULT_CHANNEL)) {
-      handleMissingRecipient(request.messageType(), rental, DEFAULT_CHANNEL);
+    NotificationChannel channel = DEFAULT_CHANNEL;
+
+    if (!request.supports(channel)) {
+      handleMissingRecipient(request.messageType(), rental, channel);
       return new NotificationDispatchResult(List.of());
     }
 
-    String recipient = request.resolveRecipient(DEFAULT_CHANNEL);
-    MessageSender sender = getMessageSender(DEFAULT_CHANNEL);
+    String recipient = request.resolveRecipient(channel);
+    MessageSender sender = getMessageSender(channel);
     try {
       sender.send(request);
       return new NotificationDispatchResult(List.of(
           new NotificationDispatchAttempt(
-              DEFAULT_CHANNEL,
+              channel,
               recipient,
               MessageSendStatus.SUCCESS
           )
       ));
-    } catch (ApplicationException e) {
-      log.error("Notification send failed. rentalId={}, messageType={}, channel={}",
-          rental.getId(), request.messageType(), DEFAULT_CHANNEL, e);
+    } catch (ApplicationException | InfraException e) {
+      if (e instanceof InfraException infraException) {
+        log.error("Notification send failed. rentalId={}, messageType={}, channel={}, errorCode={}, detail={}",
+            rental.getId(), request.messageType(), channel,
+            infraException.getErrorCode(), infraException.getDetail(), e);
+      } else {
+        log.error("Notification send failed. rentalId={}, messageType={}, channel={}",
+            rental.getId(), request.messageType(), channel, e);
+      }
       return new NotificationDispatchResult(List.of(
           new NotificationDispatchAttempt(
-              DEFAULT_CHANNEL,
+              channel,
               recipient,
               MessageSendStatus.FAIL
           )
@@ -59,7 +68,10 @@ public class NotificationDispatcher {
   private MessageSender getMessageSender(NotificationChannel channel) {
     MessageSender sender = messageSenders.get(channel);
     if (sender == null) {
-      throw new IllegalStateException("No MessageSender for channel " + channel);
+      throw new InfraException(
+          ErrorCode.MESSAGE_SENDER_NOT_FOUND,
+          "channel=" + channel
+      );
     }
     return sender;
   }
@@ -77,11 +89,18 @@ public class NotificationDispatcher {
       Rental rental,
       NotificationChannel channel
   ) {
-    if (messageType == MessageType.OVERDUE_REMINDER && channel == NotificationChannel.EMAIL) {
-      throw new ApplicationException(ErrorCode.EMAIL_NOT_FOUND);
+    if (messageType == MessageType.OVERDUE_REMINDER) {
+      throw new ApplicationException(resolveMissingRecipientError(channel));
     }
 
     log.info("Skip notification. rentalId={}, messageType={}, channel={}, reason=no recipient",
         rental.getId(), messageType, channel);
+  }
+
+  private ErrorCode resolveMissingRecipientError(NotificationChannel channel) {
+    return switch (channel) {
+      case EMAIL -> ErrorCode.EMAIL_NOT_FOUND;
+      case ALIM_TALK -> ErrorCode.INVALID_PHONE_NUMBER_EXCEPTION;
+    };
   }
 }

--- a/src/main/java/retrivr/retrivrspring/application/service/message/NotificationHistoryRecorder.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/message/NotificationHistoryRecorder.java
@@ -27,10 +27,18 @@ public class NotificationHistoryRecorder {
               attempt.recipient(),
               request.messageType(),
               attempt.status(),
-              request.content().getMessage(),
+              resolveContent(request, attempt),
               sentDate
           )
       );
     }
+  }
+
+  //todo -- 구조 개선 가능할거 같은데 getMessage()와 getTemplateMessage()를 분리하지 않는 방법 생각
+  private String resolveContent(NotificationRequest request, NotificationDispatchAttempt attempt) {
+    return switch (attempt.channel()) {
+      case EMAIL -> request.content().getMessage();
+      case ALIM_TALK -> request.content().getTemplateMessage();
+    };
   }
 }

--- a/src/main/java/retrivr/retrivrspring/application/service/message/RentalNotificationFactory.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/message/RentalNotificationFactory.java
@@ -31,26 +31,46 @@ public class RentalNotificationFactory implements NotificationFactory {
     return switch (messageType) {
       case REQUEST_COMPLETED -> new RequestCompletedContent(
           rental.getOrganization().getName(),
-          rental.getItem().getName()
+          rental.getItem().getName(),
+          resolveItemDetailName(rental),
+          rental.getRequestedAt()
       );
       case RENTAL_APPROVED -> new RentalApprovedContent(
           rental.getOrganization().getName(),
           rental.getItem().getName(),
-          rental.getDueDate()
+          resolveItemDetailName(rental),
+          rental.getDecidedAt(),
+          rental.getDueDate(),
+          rental.getItem().getRentalDuration()
       );
       case RENTAL_REJECTED -> new RentalRejectedContent(
           rental.getOrganization().getName(),
-          rental.getItem().getName()
+          rental.getItem().getName(),
+          resolveItemDetailName(rental),
+          rental.getRequestedAt()
       );
       case RETURN_CONFIRMED -> new ReturnConfirmedContent(
           rental.getOrganization().getName(),
-          rental.getItem().getName()
+          rental.getItem().getName(),
+          resolveItemDetailName(rental),
+          rental.getDecidedAt(),
+          rental.getReturnedAt()
       );
       case OVERDUE_REMINDER -> new OverdueReminderContent(
           rental.getOrganization().getName(),
           rental.getItem().getName(),
-          rental.getOverdueDays()
+          resolveItemDetailName(rental),
+          rental.getDecidedAt(),
+          rental.getDueDate(),
+          rental.getItem().getRentalDuration()
       );
     };
+  }
+
+  private String resolveItemDetailName(Rental rental) {
+    if (rental.hasItemUnit() && rental.getItemUnit() != null) {
+      return rental.getItemUnit().getLabel();
+    }
+    return rental.getItem().getName();
   }
 }

--- a/src/main/java/retrivr/retrivrspring/application/service/message/SendMessageService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/message/SendMessageService.java
@@ -37,8 +37,9 @@ public class SendMessageService {
     Organization organization = organizationRepository.findById(loginOrganizationId)
         .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_ORGANIZATION));
 
-    Rental rental = rentalRepository.findById(rentalId)
+    Rental rental = rentalRepository.findFetchBorrowerRentalItemAndOrganizationById(rentalId)
         .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_RENTAL));
+    rental = loadRentalWithItemUnits(rental);
 
     rental.validateRentalOwner(organization);
 
@@ -57,6 +58,7 @@ public class SendMessageService {
     LocalDate today = LocalDate.now();
 
     List<Rental> rentals = rentalRepository.findOverdueReminderTargets(today);
+    rentals = loadRentalsWithItemUnits(rentals);
 
     for (Rental rental : rentals) {
       if (!SendAllOverdueReminderPolicy.shouldSend(rental.getOverdueDays())) {
@@ -105,5 +107,18 @@ public class SendMessageService {
     NotificationDispatchResult result = notificationDispatcher.dispatch(notification, rental);
     notificationHistoryRecorder.record(rental, notification, result, sentDate);
     return result.hasSuccess();
+  }
+
+  private Rental loadRentalWithItemUnits(Rental rental) {
+    rentalRepository.findFetchRentalItemUnitsByRentalIn(List.of(rental));
+    return rental;
+  }
+
+  private List<Rental> loadRentalsWithItemUnits(List<Rental> rentals) {
+    if (rentals.isEmpty()) {
+      return rentals;
+    }
+    rentalRepository.findFetchRentalItemUnitsByRentalIn(rentals);
+    return rentals;
   }
 }

--- a/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
@@ -78,7 +78,13 @@ public class PublicRentalService {
 
     // 5. Rental 생성 및 저장
     String publicId = publicIdGenerator.generateRentalId(targetItem.getOrganization().getId());
-    Rental requestedRental = Rental.request(targetItem, targetItemUnit, borrower, publicId);
+    Rental requestedRental = Rental.request(
+        targetItem,
+        targetItemUnit,
+        borrower,
+        publicId,
+        request.requestNote()
+    );
 
     trySaveRental(requestedRental, targetItem.getOrganization().getId());
 

--- a/src/main/java/retrivr/retrivrspring/domain/entity/organization/PasswordHash.java
+++ b/src/main/java/retrivr/retrivrspring/domain/entity/organization/PasswordHash.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 public class PasswordHash {
 
     private static final Pattern PASSWORD_POLICY_PATTERN = Pattern.compile(
-            "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*\\p{Punct})(?!.*\\s).{8,}$"
+            "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,}$"
     );
 
     @Column(name = "password_hash", nullable = false, length = 255)

--- a/src/main/java/retrivr/retrivrspring/domain/entity/rental/Rental.java
+++ b/src/main/java/retrivr/retrivrspring/domain/entity/rental/Rental.java
@@ -90,6 +90,9 @@ public class Rental extends BaseTimeEntity {
   @Column(name = "returned_at")
   private LocalDateTime returnedAt;
 
+  @Column(name = "request_note", length = 100, nullable = true)
+  private String requestNote;
+
   private RentalState state() {
     return switch (this.status) {
       case REQUESTED -> RequestedState.INSTANCE;
@@ -100,12 +103,20 @@ public class Rental extends BaseTimeEntity {
   }
 
   public static Rental request(Item item, @Nullable ItemUnit itemUnit, Borrower borrower, String publicId) {
+    return request(item, itemUnit, borrower, publicId, null);
+  }
+
+  public static Rental request(
+      Item item, @Nullable ItemUnit itemUnit, Borrower borrower, String publicId,
+      @Nullable String requestNote
+  ) {
     Rental newRental = Rental.builder()
         .organization(item.getOrganization())
         .publicId(publicId)
         .borrower(borrower)
         .status(RentalStatus.REQUESTED)
         .requestedAt(LocalDateTime.now())
+        .requestNote(requestNote)
         .build();
 
     item.onRentalRequested(itemUnit);

--- a/src/main/java/retrivr/retrivrspring/domain/message/MessageContent.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/MessageContent.java
@@ -16,6 +16,14 @@ public abstract class MessageContent {
     return buildTemplateCode();
   }
 
+  public final String getTemplateTitle() {
+    return buildTemplateTitle();
+  }
+
+  public final String getTemplateMessage() {
+    return buildTemplateBody();
+  }
+
   public final Map<String, String> getTemplateVariables() {
     return buildTemplateVariables();
   }
@@ -30,8 +38,16 @@ public abstract class MessageContent {
     return null;
   }
 
+  protected String buildTemplateTitle() {
+    return null;
+  }
+
   protected Map<String, String> buildTemplateVariables() {
     return Map.of();
+  }
+
+  protected String buildTemplateBody() {
+    return buildBody();
   }
 
   protected abstract String buildBody();

--- a/src/main/java/retrivr/retrivrspring/domain/message/OverdueReminderContent.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/OverdueReminderContent.java
@@ -1,33 +1,59 @@
 package retrivr.retrivrspring.domain.message;
 
-public class OverdueReminderContent extends MessageContent {
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
-  private final String organizationName;
-  private final String itemName;
-  private final int overdueDays;
+public class OverdueReminderContent extends RentalMessageContentSupport {
+
+  private final LocalDateTime decidedAt;
+  private final LocalDate dueDate;
+  private final int rentalDuration;
 
   public OverdueReminderContent(
       String organizationName,
       String itemName,
-      int overdueDays
+      String itemDetailName,
+      LocalDateTime decidedAt,
+      LocalDate dueDate,
+      int rentalDuration
   ) {
-    this.organizationName = organizationName;
-    this.itemName = itemName;
-    this.overdueDays = overdueDays;
+    super(itemName, itemDetailName, organizationName);
+    this.decidedAt = decidedAt;
+    this.dueDate = dueDate;
+    this.rentalDuration = rentalDuration;
   }
 
   @Override
   protected String buildSubject() {
-    return "[Retrivr] " + itemName + " 연체 안내";
+    return "[Retrivr] " + itemName() + " 연체 안내";
   }
 
   @Override
   protected String buildBody() {
     return String.format(
-        "%s입니다.%n대여해 가신 %s이(가) %d일 연체되었습니다.%n빠른 시일 내에 반납 부탁드립니다.",
-        organizationName,
-        itemName,
-        overdueDays
+        "%s입니다.%n대여한 %s의 반납기한이 지났습니다.%n빠른 시일 내에 반납 부탁드립니다.",
+        organizationName(),
+        itemName()
+    );
+  }
+
+  @Override
+  protected String buildTemplateCode() {
+    return "rtr-v1-rental-overdue";
+  }
+
+  @Override
+  protected String buildTemplateBody() {
+    return String.join("\n",
+        itemDetailLine(),
+        templateFieldLine("대여 기간", rentalDuration + "일"),
+        templateFieldLine("대여 일시", formatDateTime(decidedAt)),
+        templateFieldLine("반납 기한", formatDate(dueDate)),
+        "",
+        "[연체 안내]",
+        organizationName() + "에서 빌려가신 물품의 반납 기한이 지났어요.",
+        "빠른 반납 부탁드릴게요.",
+        "※ 미반납 시 추가 안내가 진행될 수 있어요."
     );
   }
 }

--- a/src/main/java/retrivr/retrivrspring/domain/message/RentalApprovedContent.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/RentalApprovedContent.java
@@ -1,34 +1,59 @@
 package retrivr.retrivrspring.domain.message;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
 
-public class RentalApprovedContent extends MessageContent {
+public class RentalApprovedContent extends RentalMessageContentSupport {
 
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-  private final String organizationName;
-  private final String itemName;
+  private final LocalDateTime decidedAt;
   private final LocalDate dueDate;
+  private final int rentalDuration;
 
-  public RentalApprovedContent(String organizationName, String itemName, LocalDate dueDate) {
-    this.organizationName = organizationName;
-    this.itemName = itemName;
+  public RentalApprovedContent(
+      String organizationName,
+      String itemName,
+      String itemDetailName,
+      LocalDateTime decidedAt,
+      LocalDate dueDate,
+      int rentalDuration
+  ) {
+    super(itemName, itemDetailName, organizationName);
+    this.decidedAt = decidedAt;
     this.dueDate = dueDate;
+    this.rentalDuration = rentalDuration;
   }
 
   @Override
   protected String buildSubject() {
-    return "[Retrivr] 대여 요청이 승인되었습니다";
+    return "[Retrivr] 대여가 승인됐어요.";
   }
 
   @Override
   protected String buildBody() {
     return String.format(
-        "대여지명: %s%n대여 물품명: %s%n반납 예정일: %s%n대여 요청이 승인되었습니다.",
-        organizationName,
-        itemName,
-        dueDate.format(DATE_FORMATTER)
+        "단체명 %s%n대여 물품명 %s%n반납 예정일 %s%n대여 요청이 승인됐습니다.",
+        organizationName(),
+        itemName(),
+        dueDate
+    );
+  }
+
+  @Override
+  protected String buildTemplateCode() {
+    return "rtr-v1-rental-approved";
+  }
+
+  @Override
+  protected String buildTemplateBody() {
+    return String.join("\n",
+        itemDetailLine(),
+        templateFieldLine("대여 기간", rentalDuration + "일"),
+        templateFieldLine("대여 일시", formatDateTime(decidedAt)),
+        templateFieldLine("반납 기한", formatDate(dueDate)),
+        "",
+        "[대여 완료]",
+        organizationName() + "에서 대여가 승인됐어요.",
+        "반납 기한을 확인하고 기한 내 반납해주세요."
     );
   }
 }

--- a/src/main/java/retrivr/retrivrspring/domain/message/RentalApprovedContent.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/RentalApprovedContent.java
@@ -34,7 +34,7 @@ public class RentalApprovedContent extends RentalMessageContentSupport {
         "단체명 %s%n대여 물품명 %s%n반납 예정일 %s%n대여 요청이 승인됐습니다.",
         organizationName(),
         itemName(),
-        dueDate
+        formatDate(dueDate)
     );
   }
 

--- a/src/main/java/retrivr/retrivrspring/domain/message/RentalMessageContentSupport.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/RentalMessageContentSupport.java
@@ -48,14 +48,23 @@ abstract class RentalMessageContentSupport extends MessageContent {
   }
 
   protected String formatDateTime(LocalDateTime value) {
+    if (value == null) {
+      return "";
+    }
     return value.format(DATE_TIME_FORMATTER);
   }
 
   protected String formatDate(LocalDate value) {
+    if (value == null) {
+      return "";
+    }
     return value.format(DATE_FORMATTER);
   }
 
   protected String formatDate(LocalDateTime value) {
+    if (value == null) {
+      return "";
+    }
     return value.toLocalDate().format(DATE_FORMATTER);
   }
 }

--- a/src/main/java/retrivr/retrivrspring/domain/message/RentalMessageContentSupport.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/RentalMessageContentSupport.java
@@ -1,0 +1,61 @@
+package retrivr.retrivrspring.domain.message;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+abstract class RentalMessageContentSupport extends MessageContent {
+
+  private static final String FIELD_GAP = "      ";
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+  private static final DateTimeFormatter DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+  private final String itemName;
+  private final String itemDetailName;
+  private final String organizationName;
+
+  protected RentalMessageContentSupport(
+      String itemName,
+      String itemDetailName,
+      String organizationName
+  ) {
+    this.itemName = itemName;
+    this.itemDetailName = itemDetailName;
+    this.organizationName = organizationName;
+  }
+
+  @Override
+  protected String buildTemplateTitle() {
+    return itemName;
+  }
+
+  protected String itemDetailLine() {
+    return templateFieldLine("물품 상세", itemDetailName);
+  }
+
+  protected String templateFieldLine(String label, String value) {
+    return label + FIELD_GAP + value;
+  }
+
+  protected String organizationName() {
+    return organizationName;
+  }
+
+  protected String itemName() {
+    return itemName;
+  }
+
+  protected String formatDateTime(LocalDateTime value) {
+    return value.format(DATE_TIME_FORMATTER);
+  }
+
+  protected String formatDate(LocalDate value) {
+    return value.format(DATE_FORMATTER);
+  }
+
+  protected String formatDate(LocalDateTime value) {
+    return value.toLocalDate().format(DATE_FORMATTER);
+  }
+}

--- a/src/main/java/retrivr/retrivrspring/domain/message/RentalRejectedContent.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/RentalRejectedContent.java
@@ -1,26 +1,48 @@
 package retrivr.retrivrspring.domain.message;
 
-public class RentalRejectedContent extends MessageContent {
+import java.time.LocalDateTime;
 
-  private final String organizationName;
-  private final String itemName;
+public class RentalRejectedContent extends RentalMessageContentSupport {
 
-  public RentalRejectedContent(String organizationName, String itemName) {
-    this.organizationName = organizationName;
-    this.itemName = itemName;
+  private final LocalDateTime requestedAt;
+
+  public RentalRejectedContent(
+      String organizationName,
+      String itemName,
+      String itemDetailName,
+      LocalDateTime requestedAt
+  ) {
+    super(itemName, itemDetailName, organizationName);
+    this.requestedAt = requestedAt;
   }
 
   @Override
   protected String buildSubject() {
-    return "[Retrivr] 대여 요청이 거절되었습니다";
+    return "[Retrivr] 대여 요청이 거절됐어요.";
   }
 
   @Override
   protected String buildBody() {
     return String.format(
-        "대여지명: %s%n대여 물품명: %s%n대여 요청이 거절되었습니다.%n자세한 내용은 대여 기관에 문의해 주세요.",
-        organizationName,
-        itemName
+        "단체명 %s%n대여 물품명 %s%n대여 요청이 거절됐습니다.%n자세한 내용은 대여 기관에 문의해 주세요.",
+        organizationName(),
+        itemName()
+    );
+  }
+
+  @Override
+  protected String buildTemplateCode() {
+    return "rtr-v1-rental-request-rejected";
+  }
+
+  @Override
+  protected String buildTemplateBody() {
+    return String.join("\n",
+        templateFieldLine("요청 일시", formatDateTime(requestedAt)),
+        "",
+        "[대여 요청 거절]",
+        organizationName() + "에서 물품 대여 요청이 거절됐어요.",
+        "※ 일정 시간이 지나면 요청이 자동으로 취소될 수 있어요. 필요 시 다시 요청해주세요."
     );
   }
 }

--- a/src/main/java/retrivr/retrivrspring/domain/message/RequestCompletedContent.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/RequestCompletedContent.java
@@ -1,26 +1,50 @@
 package retrivr.retrivrspring.domain.message;
 
-public class RequestCompletedContent extends MessageContent {
+import java.time.LocalDateTime;
 
-  private final String organizationName;
-  private final String itemName;
+public class RequestCompletedContent extends RentalMessageContentSupport {
 
-  public RequestCompletedContent(String organizationName, String itemName) {
-    this.organizationName = organizationName;
-    this.itemName = itemName;
+  private final LocalDateTime requestedAt;
+
+  public RequestCompletedContent(
+      String organizationName,
+      String itemName,
+      String itemDetailName,
+      LocalDateTime requestedAt
+  ) {
+    super(itemName, itemDetailName, organizationName);
+    this.requestedAt = requestedAt;
   }
 
   @Override
   protected String buildSubject() {
-    return "[Retrivr] 대여 요청이 접수되었습니다";
+    return "[Retrivr] 대여 요청이 접수됐어요.";
   }
 
   @Override
   protected String buildBody() {
     return String.format(
-        "대여지명: %s%n대여 물품명: %s%n대여 요청이 정상적으로 접수되었습니다.%n승인 결과는 등록한 이메일로 다시 안내드리겠습니다.",
-        organizationName,
-        itemName
+        "단체명 %s%n대여 물품명 %s%n대여 요청이 정상적으로 접수됐습니다.%n확인 결과는 등록된 이메일로 다시 안내해드리겠습니다.",
+        organizationName(),
+        itemName()
+    );
+  }
+
+  @Override
+  protected String buildTemplateCode() {
+    return "rtr-v1-rental-request-complete";
+  }
+
+  @Override
+  protected String buildTemplateBody() {
+    return String.join("\n",
+        itemDetailLine(),
+        templateFieldLine("요청 일시", formatDateTime(requestedAt)),
+        "",
+        "[대여 요청 완료]",
+        organizationName() + "에서 물품 대여 요청이 접수됐어요.",
+        "관리자 승인 후 대여가 확정돼요.",
+        "※ 대여 요청은 15분간 유지됩니다."
     );
   }
 }

--- a/src/main/java/retrivr/retrivrspring/domain/message/ReturnConfirmedContent.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/ReturnConfirmedContent.java
@@ -1,26 +1,53 @@
 package retrivr.retrivrspring.domain.message;
 
-public class ReturnConfirmedContent extends MessageContent {
+import java.time.LocalDateTime;
 
-  private final String organizationName;
-  private final String itemName;
+public class ReturnConfirmedContent extends RentalMessageContentSupport {
 
-  public ReturnConfirmedContent(String organizationName, String itemName) {
-    this.organizationName = organizationName;
-    this.itemName = itemName;
+  private final LocalDateTime decidedAt;
+  private final LocalDateTime returnedAt;
+
+  public ReturnConfirmedContent(
+      String organizationName,
+      String itemName,
+      String itemDetailName,
+      LocalDateTime decidedAt,
+      LocalDateTime returnedAt
+  ) {
+    super(itemName, itemDetailName, organizationName);
+    this.decidedAt = decidedAt;
+    this.returnedAt = returnedAt;
   }
 
   @Override
   protected String buildSubject() {
-    return "[Retrivr] 반납이 확인되었습니다";
+    return "[Retrivr] 반납이 완료됐어요.";
   }
 
   @Override
   protected String buildBody() {
     return String.format(
-        "대여지명: %s%n대여 물품명: %s%n반납이 정상적으로 확인되었습니다.%n이용해주셔서 감사합니다.",
-        organizationName,
-        itemName
+        "단체명 %s%n대여 물품명 %s%n반납이 정상적으로 완료됐습니다.%n이용해주셔서 감사합니다.",
+        organizationName(),
+        itemName()
+    );
+  }
+
+  @Override
+  protected String buildTemplateCode() {
+    return "rtr-v1-rental-returned";
+  }
+
+  @Override
+  protected String buildTemplateBody() {
+    return String.join("\n",
+        itemDetailLine(),
+        templateFieldLine("대여 일시", formatDateTime(decidedAt)),
+        templateFieldLine("반납 일자", formatDate(returnedAt)),
+        "",
+        "[반납 완료]",
+        "반납이 정상적으로 완료됐어요.",
+        "이용해주셔서 감사합니다."
     );
   }
 }

--- a/src/main/java/retrivr/retrivrspring/domain/message/SendAllOverdueReminderPolicy.java
+++ b/src/main/java/retrivr/retrivrspring/domain/message/SendAllOverdueReminderPolicy.java
@@ -3,6 +3,6 @@ package retrivr.retrivrspring.domain.message;
 public class SendAllOverdueReminderPolicy {
 
   public static boolean shouldSend(long overdueDays) {
-    return overdueDays > 0 && (overdueDays == 1 || overdueDays == 3 || overdueDays % 7 == 0);
+    return overdueDays > 0 && (overdueDays == 1 || overdueDays % 7 == 0);
   }
 }

--- a/src/main/java/retrivr/retrivrspring/global/error/ErrorCode.java
+++ b/src/main/java/retrivr/retrivrspring/global/error/ErrorCode.java
@@ -110,7 +110,14 @@ public enum ErrorCode {
     // 11100: S3 Storage Error
     S3_STORAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 11100, "S3 스토리지 오류입니다."),
     EXTENSION_MUST_NOT_BE_BLANK(HttpStatus.BAD_REQUEST, 11101, "저장할 이미지의 확장자가 없습니다."),
-    UNSUPPORTED_EXTENSION(HttpStatus.BAD_REQUEST, 11102, "해당 확장자를 가진 이미지 저장이 불가합니다.");
+    UNSUPPORTED_EXTENSION(HttpStatus.BAD_REQUEST, 11102, "해당 확장자를 가진 이미지 저장이 불가합니다."),
+
+    // 11200: BizMsg Infra Error
+    BIZMSG_API_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 11200, "비즈엠 API 요청에 실패했습니다."),
+    BIZMSG_API_EMPTY_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, 11201, "비즈엠 API 응답이 비어 있습니다."),
+    BIZMSG_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 11202, "비즈엠 알림톡 발송에 실패했습니다."),
+    BIZMSG_TEMPLATE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, 11203, "비즈엠 알림톡 템플릿 정보가 올바르지 않습니다."),
+    MESSAGE_SENDER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 11204, "메시지 채널 발송기를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/retrivr/retrivrspring/global/error/InfraException.java
+++ b/src/main/java/retrivr/retrivrspring/global/error/InfraException.java
@@ -4,14 +4,26 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class InfraException extends RuntimeException {
 
   private final ErrorCode errorCode;
   private final String detail;
 
   public InfraException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
     this.errorCode = errorCode;
     this.detail = "";
+  }
+
+  public InfraException(ErrorCode errorCode, String detail) {
+    super(detail == null || detail.isBlank() ? errorCode.getMessage() : detail);
+    this.errorCode = errorCode;
+    this.detail = detail == null ? "" : detail;
+  }
+
+  public InfraException(ErrorCode errorCode, String detail, Throwable cause) {
+    super(detail == null || detail.isBlank() ? errorCode.getMessage() : detail, cause);
+    this.errorCode = errorCode;
+    this.detail = detail == null ? "" : detail;
   }
 }

--- a/src/main/java/retrivr/retrivrspring/global/properties/AlimTalkProperties.java
+++ b/src/main/java/retrivr/retrivrspring/global/properties/AlimTalkProperties.java
@@ -1,0 +1,11 @@
+package retrivr.retrivrspring.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.alim-talk")
+public record AlimTalkProperties(
+    String host,
+    String userId,
+    String profileKey
+) {
+}

--- a/src/main/java/retrivr/retrivrspring/infrastructure/message/AlimTalkMessageSender.java
+++ b/src/main/java/retrivr/retrivrspring/infrastructure/message/AlimTalkMessageSender.java
@@ -1,0 +1,78 @@
+package retrivr.retrivrspring.infrastructure.message;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import retrivr.retrivrspring.application.port.message.MessageSender;
+import retrivr.retrivrspring.application.port.message.NotificationChannel;
+import retrivr.retrivrspring.application.port.message.NotificationRequest;
+import retrivr.retrivrspring.global.error.ErrorCode;
+import retrivr.retrivrspring.global.error.InfraException;
+import retrivr.retrivrspring.global.properties.AlimTalkProperties;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AlimTalkMessageSender implements MessageSender {
+
+  private static final String MESSAGE_TYPE = "AT";
+  private static final String IMMEDIATE_SEND = "00000000000000";
+
+  private final BizMsgClient bizMsgClient;
+  private final AlimTalkProperties alimTalkProperties;
+
+  @Override
+  public NotificationChannel channel() {
+    return NotificationChannel.ALIM_TALK;
+  }
+
+  @Override
+  public void send(NotificationRequest request) {
+    String templateCode = requireValue(request.content().getTemplateCode(), "template code");
+    String templateTitle = requireValue(request.content().getTemplateTitle(), "template title");
+    String templateMessage = request.content().getTemplateMessage();
+
+    BizMsgSendRequest payload = new BizMsgSendRequest(
+        MESSAGE_TYPE,
+        request.resolveRecipient(NotificationChannel.ALIM_TALK),
+        alimTalkProperties.profileKey(),
+        templateCode,
+        templateTitle,
+        templateMessage,
+        IMMEDIATE_SEND
+    );
+
+    List<BizMsgSendResponse> responses = bizMsgClient.send(List.of(payload));
+    BizMsgSendResponse response = responses.stream()
+        .findFirst()
+        .orElseThrow(() -> new InfraException(ErrorCode.BIZMSG_API_EMPTY_RESPONSE));
+
+    if (!response.isSuccess()) {
+      log.error("BizMsg send failed. tmplId={}, title={}, msg={}, response={}",
+          templateCode, templateTitle, templateMessage, response);
+
+      ErrorCode errorCode = isNoMatchedTemplate(response.message())
+          ? ErrorCode.BIZMSG_TEMPLATE_INVALID
+          : ErrorCode.BIZMSG_SEND_FAILED;
+      throw new InfraException(
+          errorCode,
+          "code=%s, message=%s".formatted(response.code(), response.message())
+      );
+    }
+  }
+
+  private boolean isNoMatchedTemplate(String message) {
+    return message != null && message.contains("K105:NoMatchedTemplate");
+  }
+
+  private String requireValue(String value, String fieldName) {
+    if (value == null || value.isBlank()) {
+      throw new InfraException(
+          ErrorCode.BIZMSG_TEMPLATE_INVALID,
+          "Missing " + fieldName + " for AlimTalk message."
+      );
+    }
+    return value;
+  }
+}

--- a/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgClient.java
+++ b/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgClient.java
@@ -1,0 +1,116 @@
+package retrivr.retrivrspring.infrastructure.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import retrivr.retrivrspring.global.error.ErrorCode;
+import retrivr.retrivrspring.global.error.InfraException;
+import retrivr.retrivrspring.global.properties.AlimTalkProperties;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class BizMsgClient {
+
+  private static final TypeReference<List<BizMsgSendResponse>> RESPONSE_TYPE =
+      new TypeReference<>() {};
+
+  private final AlimTalkProperties alimTalkProperties;
+  private final RestClient.Builder restClientBuilder;
+  private final ObjectMapper objectMapper;
+
+  public List<BizMsgSendResponse> send(List<BizMsgSendRequest> requests) {
+    try {
+      String responseBody = restClientBuilder
+          .baseUrl(alimTalkProperties.host())
+          .build()
+          .post()
+          .uri("/v2/sender/send")
+          .contentType(MediaType.APPLICATION_JSON)
+          .header("userid", alimTalkProperties.userId())
+          .body(requests)
+          .retrieve()
+          .body(String.class);
+
+      log.warn("BizMsg raw response={}", responseBody);
+
+      if (responseBody == null || responseBody.isBlank()) {
+        throw new InfraException(ErrorCode.BIZMSG_API_EMPTY_RESPONSE);
+      }
+
+      return parseResponse(responseBody);
+    } catch (JsonProcessingException e) {
+      log.error("BizMsg response parse failed.", e);
+      throw new InfraException(ErrorCode.BIZMSG_API_REQUEST_FAILED, e.getOriginalMessage(), e);
+    } catch (RestClientException e) {
+      log.error("BizMsg API request failed.", e);
+      throw new InfraException(ErrorCode.BIZMSG_API_REQUEST_FAILED, e.getMessage(), e);
+    }
+  }
+
+  private List<BizMsgSendResponse> parseResponse(String responseBody) throws JsonProcessingException {
+    JsonNode root = objectMapper.readTree(responseBody);
+
+    if (root.isArray()) {
+      return objectMapper.readValue(responseBody, RESPONSE_TYPE);
+    }
+
+    if (!root.isObject()) {
+      throw unsupportedResponse(responseBody);
+    }
+
+    BizMsgResponseWrapper wrapper = objectMapper.treeToValue(root, BizMsgResponseWrapper.class);
+
+      if (wrapper.data() != null && !wrapper.data().isNull()) {
+      if (wrapper.data().isArray()) {
+        return objectMapper.convertValue(wrapper.data(), RESPONSE_TYPE);
+      }
+
+      if (wrapper.data().isObject()) {
+        return List.of(objectMapper.treeToValue(wrapper.data(), BizMsgSendResponse.class));
+      }
+
+      if (wrapper.data().isTextual()) {
+        return List.of(new BizMsgSendResponse(
+            wrapper.code(),
+            wrapper.data(),
+            resolveWrapperMessage(wrapper),
+            null
+        ));
+      }
+    }
+
+    if (looksLikeDirectSendResponse(root)) {
+      return List.of(objectMapper.treeToValue(root, BizMsgSendResponse.class));
+    }
+
+    throw unsupportedResponse(responseBody);
+  }
+
+  private boolean looksLikeDirectSendResponse(JsonNode root) {
+    return root.has("code") && (root.has("data") || root.has("message") || root.has("msgid"));
+  }
+
+  private String resolveWrapperMessage(BizMsgResponseWrapper wrapper) {
+    if (wrapper.error() != null && !wrapper.error().isNull()) {
+      return wrapper.message() + " | error=" + wrapper.error();
+    }
+    return wrapper.message();
+  }
+
+  private InfraException unsupportedResponse(String responseBody) {
+    log.error("Unsupported BizMsg response body={}", responseBody);
+    return new InfraException(
+        ErrorCode.BIZMSG_API_REQUEST_FAILED,
+        "Unsupported BizMsg response body: " + responseBody
+    );
+  }
+}

--- a/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgResponseWrapper.java
+++ b/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgResponseWrapper.java
@@ -1,0 +1,13 @@
+package retrivr.retrivrspring.infrastructure.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BizMsgResponseWrapper(
+    String code,
+    String message,
+    JsonNode data,
+    JsonNode error
+) {
+}

--- a/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgSendRequest.java
+++ b/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgSendRequest.java
@@ -1,0 +1,15 @@
+package retrivr.retrivrspring.infrastructure.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record BizMsgSendRequest(
+    @JsonProperty("message_type")
+    String messageType,
+    String phn,
+    String profile,
+    String tmplId,
+    String title,
+    String msg,
+    String reserveDt
+) {
+}

--- a/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgSendResponse.java
+++ b/src/main/java/retrivr/retrivrspring/infrastructure/message/BizMsgSendResponse.java
@@ -1,0 +1,17 @@
+package retrivr.retrivrspring.infrastructure.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BizMsgSendResponse(
+    String code,
+    JsonNode data,
+    String message,
+    String originMessage
+) {
+
+  public boolean isSuccess() {
+    return "success".equalsIgnoreCase(code);
+  }
+}

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/auth/EmailVerificationController.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/auth/EmailVerificationController.java
@@ -17,7 +17,7 @@ import retrivr.retrivrspring.global.error.ErrorCode;
 import retrivr.retrivrspring.global.swagger.annotation.ApiErrorCodeExamples;
 import retrivr.retrivrspring.presentation.admin.auth.req.EmailVerificationRequest;
 import retrivr.retrivrspring.presentation.admin.auth.req.EmailVerificationSendRequest;
-import retrivr.retrivrspring.presentation.admin.auth.res.EmailVerificationResponse;
+import retrivr.retrivrspring.presentation.admin.auth.res.EmailCodeVerifyTokenResponse;
 import retrivr.retrivrspring.presentation.admin.auth.res.EmailVerificationSendResponse;
 
 @RestController
@@ -54,7 +54,7 @@ public class EmailVerificationController {
     @ApiResponse(
             responseCode = "200",
             description = "이메일 인증 성공",
-            content = @Content(schema = @Schema(implementation = EmailVerificationResponse.class))
+            content = @Content(schema = @Schema(implementation = EmailCodeVerifyTokenResponse.class))
     )
     @ApiErrorCodeExamples({
             ErrorCode.EMAIL_VERIFICATION_NOT_FOUND,
@@ -63,7 +63,7 @@ public class EmailVerificationController {
             ErrorCode.EMAIL_VERIFICATION_CODE_MISMATCH
     })
     @PostMapping("/verify")
-    public ResponseEntity<?> verifyEmail(
+    public ResponseEntity<EmailCodeVerifyTokenResponse> verifyEmail(
             @Valid @RequestBody EmailVerificationRequest request
     ) {
         return ResponseEntity.ok(emailVerificationService.verify(request));

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/req/PublicRentalCreateRequest.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/req/PublicRentalCreateRequest.java
@@ -50,7 +50,15 @@ public record PublicRentalCreateRequest(
         String,
 
         @NotBlank(message = "rentalFields의 value 는 공백일 수 없습니다.")
-        String> renterFields
+        String> renterFields,
+
+    @Schema(
+        description = "요청 사항",
+        example = "대여기간 3주로 바꿔주세요",
+        nullable = true
+    )
+    @Size(max = 100, message = "요청 사항은 100자 이하로 입력해주세요.")
+    String requestNote
 ) {
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,10 @@ spring:
 
 app:
   base-url: ${SERVER_BASE_URL}
+  alim-talk:
+    host: ${ALIM_TALK_HOST}
+    user-id: ${ALIM_TALK_USER_ID}
+    profile-key: ${ALIM_TALK_PROFILE_KEY}
   email-verification:
     expires-seconds: ${EMAIL_VERIFICATION_EXPIRES_SECONDS:600}
     resend-block-seconds: ${EMAIL_VERIFICATION_RESEND_BLOCK_SECONDS:60}

--- a/src/test/java/retrivr/retrivrspring/application/service/AdminAuthServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/AdminAuthServiceTest.java
@@ -156,6 +156,65 @@ class AdminAuthServiceTest {
     }
 
     @Test
+    void signup_passwordWithDisallowedSpecialCharacter_throwsInvalidValue() {
+        SignupToken token = SignupToken.builder()
+                .email(email)
+                .tokenHash("$2a$10$signupHash")
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .build();
+        token.markCodeVerified(LocalDateTime.now());
+
+        given(signupTokenRepository.findByEmail(email)).willReturn(Optional.of(token));
+        given(passwordEncoder.matches("st_xxx", "$2a$10$signupHash")).willReturn(true);
+
+        DomainException ex = assertThrows(
+                DomainException.class,
+                () -> adminAuthService.signup(
+                        new AdminSignupRequest(email, "Password123?", "Org", "DEV", "st_xxx")
+                )
+        );
+
+        assertEquals(ErrorCode.INVALID_VALUE_EXCEPTION, ex.getErrorCode());
+    }
+
+    @Test
+    void signup_passwordWithOnlyLowercaseLettersNumberAndAllowedSpecialCharacter_succeeds() {
+        String password = "password1!";
+        String rawSignupToken = "st_xxx";
+        String hashedSignupToken = "$2a$10$signupHash";
+
+        SignupToken token = SignupToken.builder()
+                .email(email)
+                .tokenHash(hashedSignupToken)
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .build();
+
+        token.markCodeVerified(LocalDateTime.now());
+
+        given(signupTokenRepository.findByEmail(email)).willReturn(Optional.of(token));
+        given(passwordEncoder.matches(rawSignupToken, hashedSignupToken)).willReturn(true);
+        given(organizationRepository.findByEmail(email)).willReturn(Optional.empty());
+        given(passwordEncoder.encode(password)).willReturn(hashedPassword);
+        given(passwordEncoder.encode("DEV")).willReturn("encoded-admin-code");
+
+        Organization saved = Organization.builder()
+                .id(2L)
+                .email(email)
+                .passwordHash(hashedPassword)
+                .status(OrganizationStatus.PENDING)
+                .adminCodeHash("encoded-admin-code")
+                .build();
+
+        given(organizationRepository.save(any())).willReturn(saved);
+
+        var res = adminAuthService.signup(
+                new AdminSignupRequest(email, password, "Org", "DEV", rawSignupToken)
+        );
+
+        assertEquals(2L, res.orgId());
+    }
+
+    @Test
     @DisplayName("resetPassword success")
     void resetPassword_success() {
 
@@ -209,5 +268,36 @@ class AdminAuthServiceTest {
         );
 
         assertEquals(ErrorCode.PASSWORD_RESET_POLICY_VIOLATION, ex.getErrorCode());
+    }
+
+    @Test
+    void resetPassword_withAllowedSpecialCharacter_succeeds() {
+
+        Organization org = Organization.builder()
+                .id(1L)
+                .email(email)
+                .passwordHash("encoded-password")
+                .status(OrganizationStatus.ACTIVE)
+                .adminCodeHash("encoded-admin-code")
+                .build();
+
+        PasswordResetToken token = PasswordResetToken.builder()
+                .organization(org)
+                .tokenHash("$2a$10$hash")
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .build();
+
+        given(organizationRepository.findByEmail(email)).willReturn(Optional.of(org));
+        given(passwordResetTokenRepository
+                .findTopByOrganizationOrderByCreatedAtDesc(org))
+                .willReturn(Optional.of(token));
+        given(passwordEncoder.matches("token", "$2a$10$hash")).willReturn(true);
+        given(passwordEncoder.encode("NewPassword123*")).willReturn("encoded");
+
+        var res = adminAuthService.resetPassword(
+                new PasswordResetRequest(email, EmailVerificationPurpose.PASSWORD_RESET, "token", "NewPassword123*", "NewPassword123*")
+        );
+
+        assertTrue(res.success());
     }
 }

--- a/src/test/java/retrivr/retrivrspring/application/service/AdminProfileServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/AdminProfileServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import retrivr.retrivrspring.global.error.DomainException;
 
 @ExtendWith(MockitoExtension.class)
 class AdminProfileServiceTest {
@@ -150,5 +151,37 @@ class AdminProfileServiceTest {
         assertEquals(ErrorCode.PASSWORD_RESET_PASSWORD_MISMATCH, ex.getErrorCode());
         verify(passwordEncoder, times(1)).encode("NewPassword123!");
         verify(passwordEncoder, times(1)).encode("new-admin-code");
+    }
+
+    @Test
+    @DisplayName("disallowed special character in password throws INVALID_VALUE_EXCEPTION")
+    void updateProfile_passwordWithDisallowedSpecialCharacter_throws() {
+        Organization org = Organization.builder()
+                .id(1L)
+                .email("old@retrivr.com")
+                .passwordHash("old-password")
+                .name("old")
+                .status(OrganizationStatus.ACTIVE)
+                .adminCodeHash("old-code")
+                .build();
+
+        given(organizationRepository.findById(1L)).willReturn(Optional.of(org));
+
+        DomainException ex = assertThrows(
+                DomainException.class,
+                () -> adminProfileService.updateProfile(
+                        1L,
+                        new AdminProfileUpdateRequest(
+                                "new@retrivr.com",
+                                "NewPassword123?",
+                                "NewPassword123?",
+                                "New Org",
+                                "new-admin-code",
+                                "token"
+                        )
+                )
+        );
+
+        assertEquals(ErrorCode.INVALID_VALUE_EXCEPTION, ex.getErrorCode());
     }
 }

--- a/src/test/java/retrivr/retrivrspring/application/service/message/SendMessageServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/message/SendMessageServiceTest.java
@@ -56,12 +56,12 @@ class SendMessageServiceTest {
   @Test
   @DisplayName("dispatch: request completed uses email recipient and saves success history")
   void dispatch_requestCompleted_success() {
-    Rental rental = mockRental("user@test.com", "01012345678");
+    Rental rental = mockRental();
     NotificationRequest request = mock(NotificationRequest.class);
     NotificationDispatchResult result = new NotificationDispatchResult(
         java.util.List.of(new NotificationDispatchAttempt(
-            NotificationChannel.EMAIL,
-            "user@test.com",
+            NotificationChannel.ALIM_TALK,
+            "01012345678",
             MessageSendStatus.SUCCESS
         ))
     );
@@ -78,9 +78,9 @@ class SendMessageServiceTest {
   }
 
   @Test
-  @DisplayName("dispatch: request completed skips when email is missing")
-  void dispatch_requestCompleted_skipWhenEmailMissing() {
-    Rental rental = mockRental(null, "01012345678");
+  @DisplayName("dispatch: request completed skips when phone number is missing")
+  void dispatch_requestCompleted_skipWhenPhoneMissing() {
+    Rental rental = mockRental();
     NotificationRequest request = mock(NotificationRequest.class);
     NotificationDispatchResult result = new NotificationDispatchResult(java.util.List.of());
 
@@ -96,12 +96,12 @@ class SendMessageServiceTest {
   @Test
   @DisplayName("sendRentalRejected: dispatches rejected notification")
   void sendRentalRejected_dispatch() {
-    Rental rental = mock(Rental.class);
+    Rental rental = mockRental();
     NotificationRequest request = mock(NotificationRequest.class);
     NotificationDispatchResult result = new NotificationDispatchResult(
         java.util.List.of(new NotificationDispatchAttempt(
-            NotificationChannel.EMAIL,
-            "user@test.com",
+            NotificationChannel.ALIM_TALK,
+            "01012345678",
             MessageSendStatus.SUCCESS
         ))
     );
@@ -117,26 +117,26 @@ class SendMessageServiceTest {
   }
 
   @Test
-  @DisplayName("dispatch: overdue reminder throws when email is missing")
-  void dispatch_overdueReminder_throwWhenEmailMissing() {
-    Rental rental = mockRental(null, "01012345678");
+  @DisplayName("dispatch: overdue reminder throws when phone number is missing")
+  void dispatch_overdueReminder_throwWhenPhoneMissing() {
+    Rental rental = mockRental();
     NotificationRequest request = mock(NotificationRequest.class);
 
     when(notificationFactory.create(MessageType.OVERDUE_REMINDER, rental)).thenReturn(request);
-    doThrow(new ApplicationException(ErrorCode.EMAIL_NOT_FOUND))
+    doThrow(new ApplicationException(ErrorCode.INVALID_PHONE_NUMBER_EXCEPTION))
         .when(notificationDispatcher)
         .dispatch(request, rental);
 
     assertThatThrownBy(() -> service().dispatch(MessageType.OVERDUE_REMINDER, rental))
         .isInstanceOf(ApplicationException.class)
         .satisfies(exception -> assertThat(((ApplicationException) exception).getErrorCode())
-            .isEqualTo(ErrorCode.EMAIL_NOT_FOUND));
+            .isEqualTo(ErrorCode.INVALID_PHONE_NUMBER_EXCEPTION));
 
     verify(notificationHistoryRecorder, never())
         .record(any(Rental.class), any(NotificationRequest.class), any(), any(LocalDate.class));
   }
 
-  private Rental mockRental(String email, String phoneNumber) {
+  private Rental mockRental() {
     return mock(Rental.class);
   }
 }

--- a/src/test/java/retrivr/retrivrspring/infrastructure/message/BizMsgClientTest.java
+++ b/src/test/java/retrivr/retrivrspring/infrastructure/message/BizMsgClientTest.java
@@ -1,0 +1,107 @@
+package retrivr.retrivrspring.infrastructure.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import retrivr.retrivrspring.global.properties.AlimTalkProperties;
+
+class BizMsgClientTest {
+
+  @Test
+  @DisplayName("send: parses wrapped object response")
+  void send_parsesWrappedObjectResponse() {
+    RestClient.Builder builder = RestClient.builder();
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    BizMsgClient client = new BizMsgClient(
+        new AlimTalkProperties("https://bizmsg.test", "test-user", "profile-key"),
+        builder,
+        new ObjectMapper()
+    );
+
+    server.expect(requestTo("https://bizmsg.test/v2/sender/send"))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(header("userid", "test-user"))
+        .andExpect(header(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+        .andRespond(withSuccess("""
+            {
+              "code": "success",
+              "message": "ok",
+              "data": [
+                {
+                  "code": "success",
+                  "data": "accepted",
+                  "message": "sent",
+                  "type": "AT",
+                  "msgid": "msg-123"
+                }
+              ]
+            }
+            """, MediaType.APPLICATION_JSON));
+
+    List<BizMsgSendResponse> responses = client.send(List.of(new BizMsgSendRequest(
+        "AT",
+        "01012345678",
+        "profile-key",
+        "tmpl-1",
+        "title",
+        "message",
+        "00000000000000"
+    )));
+
+    assertThat(responses).hasSize(1);
+    assertThat(responses.getFirst().msgid()).isEqualTo("msg-123");
+    assertThat(responses.getFirst().isSuccess()).isTrue();
+  }
+
+  @Test
+  @DisplayName("send: parses array response")
+  void send_parsesArrayResponse() {
+    RestClient.Builder builder = RestClient.builder();
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    BizMsgClient client = new BizMsgClient(
+        new AlimTalkProperties("https://bizmsg.test", "test-user", "profile-key"),
+        builder,
+        new ObjectMapper()
+    );
+
+    server.expect(requestTo("https://bizmsg.test/v2/sender/send"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess("""
+            [
+              {
+                "code": "success",
+                "data": "accepted",
+                "message": "sent",
+                "type": "AT",
+                "msgid": "msg-123"
+              }
+            ]
+            """, MediaType.APPLICATION_JSON));
+
+    List<BizMsgSendResponse> responses = client.send(List.of(new BizMsgSendRequest(
+        "AT",
+        "01012345678",
+        "profile-key",
+        "tmpl-1",
+        "title",
+        "message",
+        "00000000000000"
+    )));
+
+    assertThat(responses).hasSize(1);
+    assertThat(responses.getFirst().msgid()).isEqualTo("msg-123");
+    assertThat(responses.getFirst().isSuccess()).isTrue();
+  }
+}

--- a/src/test/java/retrivr/retrivrspring/infrastructure/message/BizMsgClientTest.java
+++ b/src/test/java/retrivr/retrivrspring/infrastructure/message/BizMsgClientTest.java
@@ -61,8 +61,10 @@ class BizMsgClientTest {
     )));
 
     assertThat(responses).hasSize(1);
-    assertThat(responses.getFirst().msgid()).isEqualTo("msg-123");
-    assertThat(responses.getFirst().isSuccess()).isTrue();
+    assertThat(responses.get(0).code()).isEqualTo("success");
+    assertThat(responses.get(0).data().asText()).isEqualTo("accepted");
+    assertThat(responses.get(0).message()).isEqualTo("sent");
+    assertThat(responses.get(0).isSuccess()).isTrue();
   }
 
   @Test
@@ -101,7 +103,9 @@ class BizMsgClientTest {
     )));
 
     assertThat(responses).hasSize(1);
-    assertThat(responses.getFirst().msgid()).isEqualTo("msg-123");
-    assertThat(responses.getFirst().isSuccess()).isTrue();
+    assertThat(responses.get(0).code()).isEqualTo("success");
+    assertThat(responses.get(0).data().asText()).isEqualTo("accepted");
+    assertThat(responses.get(0).message()).isEqualTo("sent");
+    assertThat(responses.get(0).isSuccess()).isTrue();
   }
 }


### PR DESCRIPTION
## 🎟️ Notion Ticket
- [RTR-192](https://www.notion.so/336a569529378043ad9bd2632b691784?source=copy_link)

## 🔎 작업 내용
- 대여 요청/승인/거절/연체/반납 알림톡 메시지 구조 및 템플릿 작성                                                                                                                                                                                                          
  - 알림톡 DEFAULT_CHANNEL 고정 적용                                                                                                                                                                                                                                       
  - 알림 발송 인프라 구현                                                                                                                                                                                                                                                    
    - BizMsg 연동 클라이언트 및 예외 처리 반영                                                                                                                                                                                                                               
    - 비즈엠 주입 변수 저장 로직 추가                                                                                                                                                                                                                                        
  - 채널별 알림 내용 기록 및 공통 메시지 구조 정리                                                                                                                                                                                                                           
  - 각 Content에서 필요한 변수 주입 처리                                                                                                                                                                                                                                     
  - 연체 알림 발송 정책 변경                                                                                                                                                                                                                                                 
    - 기존 1,3,7일 -> 1,7일 (발송 비용 저감을 위해...)                                                                                                                                                                                                                                              
  - LazyException 방지를 위한 연관 객체 fetch 적용                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                             
## ✅ To Reviewer                                                                                                                                                                                                                                                           
  - 알림톡 템플릿 변수 매핑이 각 메시지 타입별 요구사항과 일치하는지 봐주세요.                                                                                                                                                                                               
  - 연체 알림 발송 주기가 `1일, 7일`로 변경된 부분이 정책 의도와 맞는지 확인 부탁드립니다.                                                                                                                                                                                   
  - 연관 객체 fetch 시점 변경이 기존 대여/메시지 플로우에 부작용이 없는지 함께 확인 부탁드립니다.                                                                                                                                                                            
                                                    

## 🧪 테스트
- [ ] 로컬 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료

## 📸 스크린샷/영상 (선택)
- 

## ⚠️ 영향도/주의사항 (선택)
-  ALIM_TALK_HOST, ALIM_TALK_USER_ID, ALIM_TALK_PROFILE_KEY 주입 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 카카오 알림톡 발송 연동 추가 및 알림톡 발송자를 기본 채널로 전환
  * 알림 템플릿(제목/본문) 지원 및 템플릿 전송 검증 추가
  * 외부 BizMsg 연동 클라이언트와 구성 속성 추가

* **개선 사항**
  * 알림에 상품 상세명·대여 기간·결정/반납/만료 일시 등 정보 포함
  * 각 비동기 알림을 개별 신규 트랜잭션으로 처리해 안정성 향상
  * 발송 실패 처리·로깅과 오류 코드 정밀화

* **기타**
  * 공개 대여 요청에 요청 메모(requestNote) 추가
  * 비밀번호 유효성 규칙 및 관련 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->