### PR TITLE
feat: public 대여 상세 조회 응답에 guaranteedGoods, contact, rentalDuration 추가

### DIFF
--- a/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
@@ -105,12 +105,16 @@ public class PublicRentalService {
         rental.getOrganization(), AdminCodeVerificationPurpose.IMMEDIATE_APPROVAL, token);
 
     //todo: 장바구니? 기능 이후 name List 를 넘기도록 수정
-    String itemName = rental.getItem().getName();
+    Item item = rental.getItem();
+    String itemName = item.getName();
+    Integer rentalDuration = item.getRentalDuration();
+    String guaranteedGoods = item.getGuaranteedGoods();
     String itemUnitLabel = null;
     if (rental.hasItemUnit()) {
       itemUnitLabel = rental.getItemUnit().getLabel();
     }
 
+    String contact = rental.getBorrower().getPhoneNumber();
     Map<String, String> borrowerField = new HashMap<>();
     if (rental.getBorrower().hasAdditionalInfo()) {
       borrowerField = objectMapper.convertValue(
@@ -119,7 +123,15 @@ public class PublicRentalService {
       );
     }
 
-    return PublicRentalDetailResponse.from(rental, itemName, itemUnitLabel, borrowerField);
+    return PublicRentalDetailResponse.from(
+        rental,
+        itemName,
+        rentalDuration,
+        itemUnitLabel,
+        contact,
+        guaranteedGoods,
+        borrowerField
+    );
   }
 
   private void trySaveRental(Rental rental, Long organizationId) {

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalDetailResponse.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalDetailResponse.java
@@ -7,7 +7,10 @@ import retrivr.retrivrspring.domain.entity.rental.Rental;
 public record PublicRentalDetailResponse(
     Long rentalId,
     String itemName,
+    Integer rentalDuration,
     String itemUnitLabel,
+    String contact,
+    String guaranteedGoods,
     Map<String, String> borrowerField,
     String requestNote,
     LocalDateTime requestedAt
@@ -16,13 +19,19 @@ public record PublicRentalDetailResponse(
   public static PublicRentalDetailResponse from(
       Rental rental,
       String itemName,
+      Integer rentalDuration,
       String itemUnitLabel,
+      String contact,
+      String guaranteedGoods,
       Map<String, String> borrowerField
   ) {
     return new PublicRentalDetailResponse(
         rental.getId(),
         itemName,
+        rentalDuration,
         itemUnitLabel,
+        contact,
+        guaranteedGoods,
         borrowerField,
         rental.getRequestNote(),
         rental.getRequestedAt()

--- a/src/test/java/retrivr/retrivrspring/application/service/rental/PublicRentalServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/rental/PublicRentalServiceTest.java
@@ -127,8 +127,8 @@ class PublicRentalServiceTest {
 
     PublicRentalCreateRequest req = mock(PublicRentalCreateRequest.class);
     when(req.itemUnitId()).thenReturn(null);
-    when(req.renterFields()).thenReturn(Map.of("학과", "컴공"));
-    when(req.name()).thenReturn("홍길동");
+    when(req.renterFields()).thenReturn(Map.of("department", "engineering"));
+    when(req.name()).thenReturn("tester");
     when(req.phone()).thenReturn("010-0000-0000");
 
     doThrow(new DomainException(ErrorCode.ILLEGAL_BORROWER_LABEL, "bad fields"))
@@ -147,8 +147,8 @@ class PublicRentalServiceTest {
 
     PublicRentalCreateRequest req = mock(PublicRentalCreateRequest.class);
     when(req.itemUnitId()).thenReturn(null);
-    when(req.renterFields()).thenReturn(Map.of("학과", "컴공"));
-    when(req.name()).thenReturn("홍길동");
+    when(req.renterFields()).thenReturn(Map.of("department", "engineering"));
+    when(req.name()).thenReturn("tester");
     when(req.phone()).thenReturn("010-0000-0000");
 
     doNothing().when(item).validationItemBorrowerFieldsWith(anyMap());
@@ -180,8 +180,8 @@ class PublicRentalServiceTest {
 
     PublicRentalCreateRequest req = mock(PublicRentalCreateRequest.class);
     when(req.itemUnitId()).thenReturn(99L);
-    when(req.renterFields()).thenReturn(Map.of("학과", "컴공"));
-    when(req.name()).thenReturn("홍길동");
+    when(req.renterFields()).thenReturn(Map.of("department", "engineering"));
+    when(req.name()).thenReturn("tester");
     when(req.phone()).thenReturn("010-0000-0000");
 
     doNothing().when(item).validationItemBorrowerFieldsWith(anyMap());
@@ -218,10 +218,12 @@ class PublicRentalServiceTest {
     when(rental.getStatus()).thenReturn(RentalStatus.REQUESTED);
     when(rental.getDecidedAt()).thenReturn((LocalDateTime) null);
     when(rental.getDueDate()).thenReturn((LocalDate) null);
-    when(rental.getRequestNote()).thenReturn("문 앞 수령");
+    when(rental.getRequestNote()).thenReturn("need charger");
 
     Item item = mock(Item.class);
-    when(item.getName()).thenReturn("카메라");
+    when(item.getName()).thenReturn("camera");
+    when(item.getRentalDuration()).thenReturn(3);
+    when(item.getGuaranteedGoods()).thenReturn("student-id");
     RentalItem rentalItem = mock(RentalItem.class);
     when(rentalItem.getItem()).thenReturn(item);
     when(rental.getRentalItems()).thenReturn(List.of(rentalItem));
@@ -229,21 +231,24 @@ class PublicRentalServiceTest {
     when(rental.getItem()).thenReturn(item);
     when(rental.hasItemUnit()).thenReturn(false);
 
-
     Borrower borrower = mock(Borrower.class);
-    JsonNode info = objectMapper.valueToTree(Map.of("학과", "컴공"));
+    JsonNode info = objectMapper.valueToTree(Map.of("department", "engineering"));
     when(borrower.getAdditionalBorrowerInfo()).thenReturn(info);
     when(borrower.hasAdditionalInfo()).thenReturn(true);
+    when(borrower.getPhoneNumber()).thenReturn("01000000000");
     when(rental.getBorrower()).thenReturn(borrower);
 
     when(rentalRepository.findById(1L)).thenReturn(Optional.of(rental));
 
     PublicRentalDetailResponse res = service().checkRentalStatusAndDetail(1L, "token");
 
-    assertThat(res.itemName()).isEqualTo("카메라");
+    assertThat(res.itemName()).isEqualTo("camera");
+    assertThat(res.rentalDuration()).isEqualTo(3);
     assertThat(res.itemUnitLabel()).isNull();
-    assertThat(res.borrowerField()).containsEntry("학과", "컴공");
-    assertThat(res.requestNote()).isEqualTo("문 앞 수령");
+    assertThat(res.contact()).isEqualTo("01000000000");
+    assertThat(res.guaranteedGoods()).isEqualTo("student-id");
+    assertThat(res.borrowerField()).containsEntry("department", "engineering");
+    assertThat(res.requestNote()).isEqualTo("need charger");
   }
 
   @Test
@@ -254,15 +259,16 @@ class PublicRentalServiceTest {
     when(rental.getStatus()).thenReturn(RentalStatus.RENTED);
     when(rental.getDecidedAt()).thenReturn(LocalDateTime.now());
     when(rental.getDueDate()).thenReturn(LocalDate.now().plusDays(7));
-    when(rental.getRequestNote()).thenReturn("충전기 같이 요청");
+    when(rental.getRequestNote()).thenReturn("need adapter too");
 
     Item item = mock(Item.class);
-    when(item.getName()).thenReturn("노트북");
+    when(item.getName()).thenReturn("laptop");
+    when(item.getRentalDuration()).thenReturn(7);
+    when(item.getGuaranteedGoods()).thenReturn("government-id");
     RentalItem rentalItem = mock(RentalItem.class);
     when(rentalItem.getItem()).thenReturn(item);
     when(rental.getRentalItems()).thenReturn(List.of(rentalItem));
     when(rental.getItem()).thenReturn(item);
-
 
     ItemUnit unit = mock(ItemUnit.class);
     when(unit.getLabel()).thenReturn("unit-001");
@@ -272,22 +278,26 @@ class PublicRentalServiceTest {
     when(rental.getItemUnit()).thenReturn(unit);
     when(rental.hasItemUnit()).thenReturn(true);
 
-
     Borrower borrower = mock(Borrower.class);
-    JsonNode info = objectMapper.valueToTree(Map.of("학번", "20251234"));
+    JsonNode info = objectMapper.valueToTree(Map.of("studentNo", "20251234"));
     when(borrower.getAdditionalBorrowerInfo()).thenReturn(info);
     when(borrower.hasAdditionalInfo()).thenReturn(true);
+    when(borrower.getPhoneNumber()).thenReturn("01012345678");
     when(rental.getBorrower()).thenReturn(borrower);
 
     when(rentalRepository.findById(2L)).thenReturn(Optional.of(rental));
 
     PublicRentalDetailResponse res = service().checkRentalStatusAndDetail(2L, "token");
 
-    assertThat(res.itemName()).isEqualTo("노트북");
+    assertThat(res.itemName()).isEqualTo("laptop");
+    assertThat(res.rentalDuration()).isEqualTo(7);
     assertThat(res.itemUnitLabel()).isEqualTo("unit-001");
-    assertThat(res.borrowerField()).containsEntry("학번", "20251234");
-    assertThat(res.requestNote()).isEqualTo("충전기 같이 요청");
+    assertThat(res.contact()).isEqualTo("01012345678");
+    assertThat(res.guaranteedGoods()).isEqualTo("government-id");
+    assertThat(res.borrowerField()).containsEntry("studentNo", "20251234");
+    assertThat(res.requestNote()).isEqualTo("need adapter too");
   }
+
   private void setRentalId(Rental rental, Long rentalId) {
     try {
       java.lang.reflect.Field idField = Rental.class.getDeclaredField("id");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 공개 임대 상세 정보 조회 응답이 확장되었습니다. 임대 기간, 차용자 연락처, 보증물품 정보가 새로 추가되어 사용자는 임대 요청의 더욱 완전한 세부 사항을 확인할 수 있습니다. 임대 관련 모든 필수 정보를 한 곳에서 조회할 수 있게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->