### PR TITLE
feat: public 대여 상세 조회 응답에 borrowerName 추가

### DIFF
--- a/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/open/PublicRentalService.java
@@ -114,6 +114,7 @@ public class PublicRentalService {
       itemUnitLabel = rental.getItemUnit().getLabel();
     }
 
+    String borrowerName = rental.getBorrower().getName();
     String contact = rental.getBorrower().getPhoneNumber();
     Map<String, String> borrowerField = new HashMap<>();
     if (rental.getBorrower().hasAdditionalInfo()) {
@@ -128,6 +129,7 @@ public class PublicRentalService {
         itemName,
         rentalDuration,
         itemUnitLabel,
+        borrowerName,
         contact,
         guaranteedGoods,
         borrowerField

--- a/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalDetailResponse.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/open/rental/res/PublicRentalDetailResponse.java
@@ -9,6 +9,7 @@ public record PublicRentalDetailResponse(
     String itemName,
     Integer rentalDuration,
     String itemUnitLabel,
+    String borrowerName,
     String contact,
     String guaranteedGoods,
     Map<String, String> borrowerField,
@@ -21,6 +22,7 @@ public record PublicRentalDetailResponse(
       String itemName,
       Integer rentalDuration,
       String itemUnitLabel,
+      String borrowerName,
       String contact,
       String guaranteedGoods,
       Map<String, String> borrowerField
@@ -30,6 +32,7 @@ public record PublicRentalDetailResponse(
         itemName,
         rentalDuration,
         itemUnitLabel,
+        borrowerName,
         contact,
         guaranteedGoods,
         borrowerField,

--- a/src/test/java/retrivr/retrivrspring/application/service/rental/PublicRentalServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/rental/PublicRentalServiceTest.java
@@ -235,6 +235,7 @@ class PublicRentalServiceTest {
     JsonNode info = objectMapper.valueToTree(Map.of("department", "engineering"));
     when(borrower.getAdditionalBorrowerInfo()).thenReturn(info);
     when(borrower.hasAdditionalInfo()).thenReturn(true);
+    when(borrower.getName()).thenReturn("tester");
     when(borrower.getPhoneNumber()).thenReturn("01000000000");
     when(rental.getBorrower()).thenReturn(borrower);
 
@@ -245,6 +246,7 @@ class PublicRentalServiceTest {
     assertThat(res.itemName()).isEqualTo("camera");
     assertThat(res.rentalDuration()).isEqualTo(3);
     assertThat(res.itemUnitLabel()).isNull();
+    assertThat(res.borrowerName()).isEqualTo("tester");
     assertThat(res.contact()).isEqualTo("01000000000");
     assertThat(res.guaranteedGoods()).isEqualTo("student-id");
     assertThat(res.borrowerField()).containsEntry("department", "engineering");
@@ -282,6 +284,7 @@ class PublicRentalServiceTest {
     JsonNode info = objectMapper.valueToTree(Map.of("studentNo", "20251234"));
     when(borrower.getAdditionalBorrowerInfo()).thenReturn(info);
     when(borrower.hasAdditionalInfo()).thenReturn(true);
+    when(borrower.getName()).thenReturn("kim");
     when(borrower.getPhoneNumber()).thenReturn("01012345678");
     when(rental.getBorrower()).thenReturn(borrower);
 
@@ -292,6 +295,7 @@ class PublicRentalServiceTest {
     assertThat(res.itemName()).isEqualTo("laptop");
     assertThat(res.rentalDuration()).isEqualTo(7);
     assertThat(res.itemUnitLabel()).isEqualTo("unit-001");
+    assertThat(res.borrowerName()).isEqualTo("kim");
     assertThat(res.contact()).isEqualTo("01012345678");
     assertThat(res.guaranteedGoods()).isEqualTo("government-id");
     assertThat(res.borrowerField()).containsEntry("studentNo", "20251234");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 렌탈 상세 정보 응답에 대여자의 이름이 새로 추가되었습니다. 사용자가 렌탈 정보를 조회할 때 물품을 대여한 사람의 이름을 곧바로 확인할 수 있습니다.

* **테스트**
  * 렌탈 상세 정보 응답에서 대여자 이름이 정확하게 포함되어 반환되는지 검증하는 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->