### PR TITLE
feat:[RTR-153] CHANGE_EMAIL 이메일 인증 API를 admin 인증 기반으로 분리

### DIFF
--- a/src/main/java/retrivr/retrivrspring/application/service/admin/auth/EmailVerificationService.java
+++ b/src/main/java/retrivr/retrivrspring/application/service/admin/auth/EmailVerificationService.java
@@ -8,11 +8,11 @@ import retrivr.retrivrspring.domain.entity.organization.EmailVerification;
 import retrivr.retrivrspring.domain.entity.organization.Organization;
 import retrivr.retrivrspring.domain.entity.organization.PasswordResetToken;
 import retrivr.retrivrspring.domain.entity.organization.SignupToken;
-import retrivr.retrivrspring.domain.repository.auth.EmailVerificationRepository;
-import retrivr.retrivrspring.domain.repository.auth.SignupTokenRepository;
 import retrivr.retrivrspring.domain.entity.organization.enumerate.EmailVerificationPurpose;
-import retrivr.retrivrspring.domain.repository.organization.OrganizationRepository;
+import retrivr.retrivrspring.domain.repository.auth.EmailVerificationRepository;
 import retrivr.retrivrspring.domain.repository.auth.PasswordResetTokenRepository;
+import retrivr.retrivrspring.domain.repository.auth.SignupTokenRepository;
+import retrivr.retrivrspring.domain.repository.organization.OrganizationRepository;
 import retrivr.retrivrspring.global.error.ApplicationException;
 import retrivr.retrivrspring.global.error.ErrorCode;
 import retrivr.retrivrspring.global.properties.EmailVerificationProperties;
@@ -26,7 +26,6 @@ import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.UUID;
 
-//todo email 인증을 redis 기반으로 바꿀 수 있을지도
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -51,53 +50,62 @@ public class EmailVerificationService {
         EmailVerification verification = emailVerificationRepository
                 .findByEmailAndPurpose(email, purpose)
                 .map(existing -> {
-                    // 재전송 제한
-                    if (existing.getUpdatedAt() != null && existing.getUpdatedAt().isAfter(now.minusSeconds(emailVerificationProperties.getResendBlockSeconds()))) {
+                    if (existing.getUpdatedAt() != null
+                            && existing.getUpdatedAt().isAfter(now.minusSeconds(emailVerificationProperties.getResendBlockSeconds()))) {
                         throw new ApplicationException(ErrorCode.EMAIL_VERIFICATION_TOO_MANY_REQUESTS);
                     }
 
                     existing.refresh(hashedCode, now.plusSeconds(emailVerificationProperties.getExpiresSeconds()));
                     return existing;
                 })
-                .orElseGet(() ->
-                        EmailVerification.create(
-                                email,
-                                purpose,
-                                hashedCode,
-                                now.plusSeconds(emailVerificationProperties.getExpiresSeconds())
-                        )
-                );
+                .orElseGet(() -> EmailVerification.create(
+                        email,
+                        purpose,
+                        hashedCode,
+                        now.plusSeconds(emailVerificationProperties.getExpiresSeconds())
+                ));
 
-        switch(verification.getPurpose()) {
+        switch (verification.getPurpose()) {
             case SIGNUP:
                 signupTokenRepository.deleteByEmail(email);
                 break;
             case PASSWORD_RESET:
                 Organization organization = organizationRepository.findByEmail(email)
-                    .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_ORGANIZATION));
+                        .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_ORGANIZATION));
                 passwordResetTokenRepository.deleteByOrganization(organization);
                 break;
             case EMAIL_CHANGE:
-                // todo: Email 변경은 기획에서 사라짐
                 break;
         }
+
         emailVerificationRepository.save(verification);
-        emailVerificationCodeSender.sendVerificationCode(email, rawCode, purpose, emailVerificationProperties.getExpiresSeconds());
-        return new EmailVerificationSendResponse(email, purpose.name(), emailVerificationProperties.getExpiresSeconds());
+        emailVerificationCodeSender.sendVerificationCode(
+                email,
+                rawCode,
+                purpose,
+                emailVerificationProperties.getExpiresSeconds()
+        );
+        return new EmailVerificationSendResponse(
+                email,
+                purpose.name(),
+                emailVerificationProperties.getExpiresSeconds()
+        );
+    }
+
+    public EmailVerificationSendResponse sendChangeEmailCode(EmailVerificationSendRequest request) {
+        validateEmailChangePurpose(request.purpose());
+        return sendCode(request);
     }
 
     @Transactional(noRollbackFor = ApplicationException.class)
     public EmailCodeVerifyTokenResponse verify(EmailVerificationRequest request) {
-
         String email = request.email().trim().toLowerCase(Locale.ROOT);
         EmailVerificationPurpose purpose = request.purpose();
         String code = request.code();
 
         EmailVerification verification = emailVerificationRepository
                 .findByEmailAndPurpose(email, purpose)
-                .orElseThrow(() ->
-                        new ApplicationException(ErrorCode.EMAIL_VERIFICATION_NOT_FOUND)
-                );
+                .orElseThrow(() -> new ApplicationException(ErrorCode.EMAIL_VERIFICATION_NOT_FOUND));
 
         LocalDateTime now = LocalDateTime.now();
 
@@ -124,7 +132,6 @@ public class EmailVerificationService {
 
         verification.markVerified(now);
 
-        // SIGNUP이면 signupToken 생성
         if (purpose == EmailVerificationPurpose.SIGNUP) {
             String rawSignupToken = "st_" + UUID.randomUUID();
             String signupTokenHash = passwordEncoder.encode(rawSignupToken);
@@ -138,10 +145,12 @@ public class EmailVerificationService {
                     .build();
 
             token.markCodeVerified(now);
-
             signupTokenRepository.save(token);
 
-            return EmailCodeVerifyTokenResponse.signupToken(rawSignupToken, emailVerificationProperties.getExpiresSeconds());
+            return EmailCodeVerifyTokenResponse.signupToken(
+                    rawSignupToken,
+                    emailVerificationProperties.getExpiresSeconds()
+            );
         }
 
         if (purpose == EmailVerificationPurpose.PASSWORD_RESET) {
@@ -178,9 +187,21 @@ public class EmailVerificationService {
         throw new ApplicationException(ErrorCode.INVALID_VALUE_EXCEPTION);
     }
 
+    @Transactional(noRollbackFor = ApplicationException.class)
+    public EmailCodeVerifyTokenResponse verifyChangeEmail(EmailVerificationRequest request) {
+        validateEmailChangePurpose(request.purpose());
+        return verify(request);
+    }
+
     private String generateCode() {
         SecureRandom random = new SecureRandom();
         int number = random.nextInt(900000) + 100000;
         return String.valueOf(number);
+    }
+
+    private void validateEmailChangePurpose(EmailVerificationPurpose purpose) {
+        if (purpose != EmailVerificationPurpose.EMAIL_CHANGE) {
+            throw new ApplicationException(ErrorCode.INVALID_VALUE_EXCEPTION);
+        }
     }
 }

--- a/src/main/java/retrivr/retrivrspring/presentation/admin/auth/EmailVerificationController.java
+++ b/src/main/java/retrivr/retrivrspring/presentation/admin/auth/EmailVerificationController.java
@@ -1,6 +1,7 @@
 package retrivr.retrivrspring.presentation.admin.auth;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import retrivr.retrivrspring.application.service.admin.auth.EmailVerificationService;
+import retrivr.retrivrspring.global.auth.AuthOrg;
+import retrivr.retrivrspring.global.auth.AuthUser;
 import retrivr.retrivrspring.global.error.ErrorCode;
 import retrivr.retrivrspring.global.swagger.annotation.ApiErrorCodeExamples;
 import retrivr.retrivrspring.presentation.admin.auth.req.EmailVerificationRequest;
@@ -21,16 +24,16 @@ import retrivr.retrivrspring.presentation.admin.auth.res.EmailCodeVerifyTokenRes
 import retrivr.retrivrspring.presentation.admin.auth.res.EmailVerificationSendResponse;
 
 @RestController
-@RequestMapping("/api/public/v1/email/verification")
-@Tag(name = "Public API / Email Verification", description = "이메일 인증 관련 API")
+@RequestMapping("/api")
+@Tag(name = "Email Verification", description = "이메일 인증 관련 API")
 @RequiredArgsConstructor
 public class EmailVerificationController {
 
     private final EmailVerificationService emailVerificationService;
 
-    @PostMapping
+    @PostMapping("/public/v1/email/verification")
     @Operation(
-            summary = "UC-1.3.0 이메일 인증 코드 발송",
+            summary = "public 이메일 인증 코드 발송",
             description = "이메일과 인증 목적에 따라 6자리 인증 코드를 발송한다."
     )
     @ApiResponse(
@@ -42,13 +45,12 @@ public class EmailVerificationController {
     public ResponseEntity<EmailVerificationSendResponse> sendEmailVerificationCode(
             @Valid @RequestBody EmailVerificationSendRequest request
     ) {
-        return ResponseEntity.ok(
-                emailVerificationService.sendCode(request)
-        );
+        return ResponseEntity.ok(emailVerificationService.sendCode(request));
     }
 
+    @PostMapping("/public/v1/email/verification/verify")
     @Operation(
-            summary = "UC-1.3.1 이메일 인증 코드 검증",
+            summary = "public 이메일 인증 코드 검증",
             description = "이메일, 목적, 인증 코드를 검증하고 인증을 완료한다."
     )
     @ApiResponse(
@@ -62,10 +64,54 @@ public class EmailVerificationController {
             ErrorCode.EMAIL_ALREADY_VERIFIED,
             ErrorCode.EMAIL_VERIFICATION_CODE_MISMATCH
     })
-    @PostMapping("/verify")
     public ResponseEntity<EmailCodeVerifyTokenResponse> verifyEmail(
             @Valid @RequestBody EmailVerificationRequest request
     ) {
         return ResponseEntity.ok(emailVerificationService.verify(request));
+    }
+
+    @PostMapping("/admin/v1/email/verification")
+    @Operation(
+            summary = "admin 이메일 인증 코드 발송",
+            description = "관리자 정보 수정 시 이메일 변경을 위해 6자리 인증 코드를 발송한다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "인증 코드 발송 성공",
+            content = @Content(schema = @Schema(implementation = EmailVerificationSendResponse.class))
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.EMAIL_VERIFICATION_TOO_MANY_REQUESTS,
+            ErrorCode.INVALID_VALUE_EXCEPTION
+    })
+    public ResponseEntity<EmailVerificationSendResponse> sendAdminEmailVerificationCode(
+            @Parameter(hidden = true) @AuthOrg AuthUser authUser,
+            @Valid @RequestBody EmailVerificationSendRequest request
+    ) {
+        return ResponseEntity.ok(emailVerificationService.sendChangeEmailCode(request));
+    }
+
+    @PostMapping("/admin/v1/email/verification/verify")
+    @Operation(
+            summary = "admin 이메일 인증 코드 검증",
+            description = "로그인 정보, 이메일, 목적, 인증 코드를 검증하고 인증을 완료한다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "이메일 인증 성공",
+            content = @Content(schema = @Schema(implementation = EmailCodeVerifyTokenResponse.class))
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.EMAIL_VERIFICATION_NOT_FOUND,
+            ErrorCode.EMAIL_VERIFICATION_EXPIRED,
+            ErrorCode.EMAIL_ALREADY_VERIFIED,
+            ErrorCode.EMAIL_VERIFICATION_CODE_MISMATCH,
+            ErrorCode.INVALID_VALUE_EXCEPTION
+    })
+    public ResponseEntity<EmailCodeVerifyTokenResponse> verifyAdminEmail(
+            @Parameter(hidden = true) @AuthOrg AuthUser authUser,
+            @Valid @RequestBody EmailVerificationRequest request
+    ) {
+        return ResponseEntity.ok(emailVerificationService.verifyChangeEmail(request));
     }
 }

--- a/src/test/java/retrivr/retrivrspring/application/service/EmailVerificationServiceTest.java
+++ b/src/test/java/retrivr/retrivrspring/application/service/EmailVerificationServiceTest.java
@@ -29,8 +29,18 @@ import retrivr.retrivrspring.presentation.admin.auth.res.EmailCodeVerifyTokenRes
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EmailVerificationServiceTest {
@@ -107,6 +117,19 @@ class EmailVerificationServiceTest {
     }
 
     @Test
+    void sendChangeEmailCode_rejectsNonEmailChangePurpose() {
+        ApplicationException ex = assertThrows(
+                ApplicationException.class,
+                () -> emailVerificationService.sendChangeEmailCode(
+                        new EmailVerificationSendRequest(email, EmailVerificationPurpose.SIGNUP)
+                )
+        );
+
+        assertEquals(ErrorCode.INVALID_VALUE_EXCEPTION, ex.getErrorCode());
+        verifyNoInteractions(emailVerificationRepository, emailVerificationCodeSender);
+    }
+
+    @Test
     void verify_success_signup_generates_token() {
         EmailVerification verification = EmailVerification.create(
                 email,
@@ -120,12 +143,10 @@ class EmailVerificationServiceTest {
         when(passwordEncoder.matches("123456", "hashed")).thenReturn(true);
         when(passwordEncoder.encode(any())).thenReturn("signupTokenHash");
 
-        var response = emailVerificationService.verify(
+        EmailCodeVerifyTokenResponse tokenResponse = emailVerificationService.verify(
                 new EmailVerificationRequest(email, EmailVerificationPurpose.SIGNUP, "123456")
         );
 
-        assertTrue(response instanceof EmailCodeVerifyTokenResponse);
-        EmailCodeVerifyTokenResponse tokenResponse = (EmailCodeVerifyTokenResponse) response;
         assertEquals("SIGNUP", tokenResponse.tokenType());
         assertNotNull(tokenResponse.token());
         assertTrue(tokenResponse.token().startsWith("st_"));
@@ -183,12 +204,10 @@ class EmailVerificationServiceTest {
         when(organizationRepository.findByEmail(email)).thenReturn(Optional.of(org));
         when(passwordEncoder.encode(any())).thenReturn("passwordResetTokenHash");
 
-        var response = emailVerificationService.verify(
+        EmailCodeVerifyTokenResponse tokenResponse = emailVerificationService.verify(
                 new EmailVerificationRequest(email, EmailVerificationPurpose.PASSWORD_RESET, "123456")
         );
 
-        assertTrue(response instanceof EmailCodeVerifyTokenResponse);
-        EmailCodeVerifyTokenResponse tokenResponse = (EmailCodeVerifyTokenResponse) response;
         assertEquals("PASSWORD_RESET", tokenResponse.tokenType());
         assertNotNull(tokenResponse.token());
         assertTrue(tokenResponse.token().startsWith("prt_"));
@@ -199,7 +218,7 @@ class EmailVerificationServiceTest {
     }
 
     @Test
-    void verify_success_emailChange_generates_token() {
+    void verifyChangeEmail_success_generates_token() {
         EmailVerification verification = EmailVerification.create(
                 email,
                 EmailVerificationPurpose.EMAIL_CHANGE,
@@ -211,145 +230,27 @@ class EmailVerificationServiceTest {
                 .thenReturn(Optional.of(verification));
         when(passwordEncoder.matches("123456", "hashed")).thenReturn(true);
 
-        var response = emailVerificationService.verify(
+        EmailCodeVerifyTokenResponse tokenResponse = emailVerificationService.verifyChangeEmail(
                 new EmailVerificationRequest(email, EmailVerificationPurpose.EMAIL_CHANGE, "123456")
         );
 
-        assertTrue(response instanceof EmailCodeVerifyTokenResponse);
-        EmailCodeVerifyTokenResponse tokenResponse = (EmailCodeVerifyTokenResponse) response;
         assertEquals("EMAIL_CHANGE", tokenResponse.tokenType());
         assertNotNull(tokenResponse.token());
         assertTrue(tokenResponse.token().startsWith("ect_"));
         assertEquals(600, tokenResponse.expiresInSeconds());
-        verifyNoInteractions(signupTokenRepository, organizationRepository, passwordResetTokenRepository);
+        verifyNoInteractions(signupTokenRepository, passwordResetTokenRepository);
     }
 
     @Test
-    void verify_codeMismatch_locksWhenFailedAttemptsReachThreshold() {
-        EmailVerification verification = EmailVerification.create(
-                email,
-                EmailVerificationPurpose.SIGNUP,
-                "hashed",
-                LocalDateTime.now().plusMinutes(10)
-        );
-        ReflectionTestUtils.setField(verification, "failedAttempts", 4);
-
-        when(emailVerificationRepository.findByEmailAndPurpose(email, EmailVerificationPurpose.SIGNUP))
-                .thenReturn(Optional.of(verification));
-        when(passwordEncoder.matches("123456", "hashed")).thenReturn(false);
-
+    void verifyChangeEmail_rejectsNonEmailChangePurpose() {
         ApplicationException ex = assertThrows(
                 ApplicationException.class,
-                () -> emailVerificationService.verify(
+                () -> emailVerificationService.verifyChangeEmail(
                         new EmailVerificationRequest(email, EmailVerificationPurpose.SIGNUP, "123456")
                 )
         );
 
-        assertEquals(ErrorCode.EMAIL_VERIFICATION_EXPIRED, ex.getErrorCode());
-        assertEquals(5, ReflectionTestUtils.getField(verification, "failedAttempts"));
-        assertTrue(verification.isExpired(LocalDateTime.now().plusSeconds(1)));
-        verify(emailVerificationRepository, times(1)).save(verification);
-    }
-
-    @Test
-    void verify_lockedAfterThreshold_subsequentAttemptRejectedBeforeMatches() {
-        EmailVerification verification = EmailVerification.create(
-                email,
-                EmailVerificationPurpose.SIGNUP,
-                "hashed",
-                LocalDateTime.now().plusMinutes(10)
-        );
-        ReflectionTestUtils.setField(verification, "failedAttempts", 4);
-
-        when(emailVerificationRepository.findByEmailAndPurpose(email, EmailVerificationPurpose.SIGNUP))
-                .thenReturn(Optional.of(verification));
-        when(passwordEncoder.matches("123456", "hashed")).thenReturn(false);
-
-        assertThrows(
-                ApplicationException.class,
-                () -> emailVerificationService.verify(
-                        new EmailVerificationRequest(email, EmailVerificationPurpose.SIGNUP, "123456")
-                )
-        );
-        verify(emailVerificationRepository, times(1)).save(verification);
-
-        ApplicationException ex = assertThrows(
-                ApplicationException.class,
-                () -> emailVerificationService.verify(
-                        new EmailVerificationRequest(email, EmailVerificationPurpose.SIGNUP, "123456")
-                )
-        );
-
-        assertEquals(ErrorCode.EMAIL_VERIFICATION_EXPIRED, ex.getErrorCode());
-        verify(passwordEncoder, times(1)).matches("123456", "hashed");
-    }
-
-    @Test
-    void verify_success_resetsFailedAttempts() {
-        EmailVerification verification = EmailVerification.create(
-                email,
-                EmailVerificationPurpose.SIGNUP,
-                "hashed",
-                LocalDateTime.now().plusMinutes(10)
-        );
-        ReflectionTestUtils.setField(verification, "failedAttempts", 3);
-
-        when(emailVerificationRepository.findByEmailAndPurpose(email, EmailVerificationPurpose.SIGNUP))
-                .thenReturn(Optional.of(verification));
-        when(passwordEncoder.matches("123456", "hashed")).thenReturn(true);
-        when(passwordEncoder.encode(any())).thenReturn("signupTokenHash");
-
-        emailVerificationService.verify(
-                new EmailVerificationRequest(email, EmailVerificationPurpose.SIGNUP, "123456")
-        );
-
-        assertEquals(0, ReflectionTestUtils.getField(verification, "failedAttempts"));
-        verify(signupTokenRepository, times(1)).deleteByEmail(email);
-    }
-
-    @Test
-    void verify_expired() {
-        EmailVerification verification = EmailVerification.create(
-                email,
-                EmailVerificationPurpose.SIGNUP,
-                "hashed",
-                LocalDateTime.now().minusMinutes(1)
-        );
-
-        when(emailVerificationRepository.findByEmailAndPurpose(email, EmailVerificationPurpose.SIGNUP))
-                .thenReturn(Optional.of(verification));
-
-        ApplicationException ex = assertThrows(
-                ApplicationException.class,
-                () -> emailVerificationService.verify(
-                        new EmailVerificationRequest(email, EmailVerificationPurpose.SIGNUP, "123456")
-                )
-        );
-
-        assertEquals(ErrorCode.EMAIL_VERIFICATION_EXPIRED, ex.getErrorCode());
-    }
-
-    @Test
-    void verify_alreadyVerified() {
-        EmailVerification verification = EmailVerification.create(
-                email,
-                EmailVerificationPurpose.SIGNUP,
-                "hashed",
-                LocalDateTime.now().plusMinutes(10)
-        );
-
-        verification.markVerified(LocalDateTime.now());
-
-        when(emailVerificationRepository.findByEmailAndPurpose(email, EmailVerificationPurpose.SIGNUP))
-                .thenReturn(Optional.of(verification));
-
-        ApplicationException ex = assertThrows(
-                ApplicationException.class,
-                () -> emailVerificationService.verify(
-                        new EmailVerificationRequest(email, EmailVerificationPurpose.SIGNUP, "123456")
-                )
-        );
-
-        assertEquals(ErrorCode.EMAIL_ALREADY_VERIFIED, ex.getErrorCode());
+        assertEquals(ErrorCode.INVALID_VALUE_EXCEPTION, ex.getErrorCode());
+        verifyNoInteractions(emailVerificationRepository);
     }
 }


### PR DESCRIPTION
## 🎟️ Notion Ticket
- [RTR-153](https://www.notion.so/api-322a5695293780ffb978f495362eb5a1?source=copy_link)

## 🔎 작업 내용
  - public 이메일 인증 API는 기존 경로와 동작을 유지합니다.
  - 이메일 변경(EMAIL_CHANGE)용 이메일 인증은 별도의 admin API로 분리했습니다.
  - admin 이메일 변경 API는 @AuthOrg 기반 인증을 거치고, 서비스에서는 이메일 변경 purpose만 허용하도록 분리했습니다.
  - @AuthOrg 인증과 purpose 인등 이후에는 public 이메일 인증 API와 같은 동작을 합니다.
 
## ✅ To Reviewer
- 구조는 public = 기존 범용 이메일 인증, admin = 이메일 변경 전용 인증으로 나뉩니다.                                        
- 로그인 검증은 서비스가 아니라 컨트롤러의 @AuthOrg를 통해 수행됩니다.

## 🧪 테스트
- [ ] 로컬 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이메일 변경 검증 기능이 추가되었습니다.
  * 관리자용 이메일 검증 엔드포인트가 새로 추가되었습니다.

* **개선 사항**
  * API 엔드포인트가 버전별로 체계적으로 정렬되었습니다.
  * 공개 및 관리자 기능이 명확하게 분리되었습니다.

* **테스트**
  * 이메일 변경 검증 기능에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->